### PR TITLE
fix: add code and codespase to error response

### DIFF
--- a/client/context/query.go
+++ b/client/context/query.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // GetNode returns an RPC client. If the context's client is not defined, an
@@ -95,7 +96,7 @@ func (ctx CLIContext) query(path string, key tmbytes.HexBytes) (res []byte, heig
 
 	resp := result.Response
 	if !resp.IsOK() {
-		return res, resp.Height, errors.New(resp.Log)
+		return res, resp.Height, sdkerrors.ABCIError(resp.Codespace, resp.Code, resp.Log)
 	}
 
 	// data from trusted node or subspace query doesn't need verification


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`Code` and `Codespace` are missing from the error responses when querying states.

- problem example:
```json
{"error":"token symbol, token-id does not exist: 678c146a 100000010000000e"}
```

- expected response
```json
{"error": "{\"codespace\":\"collection\",\"code\":2,\"message\":\"token contract_id[678c146a] token-id[1000000100000013] does not exist\"}"}
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.