### PR TITLE
fix: check internalABCICodespace 

### DIFF
--- a/types/errors/abci.go
+++ b/types/errors/abci.go
@@ -162,7 +162,7 @@ func Redact(err error) error {
 	if ErrPanic.Is(err) {
 		return errors.New(internalABCILog)
 	}
-	if abciCode(err) == internalABCICode && abciCodespace(err) == UndefinedCodespace{
+	if abciCode(err) == internalABCICode && abciCodespace(err) == internalABCICodespace{
 		return errors.New(internalABCILog)
 	}
 	return err


### PR DESCRIPTION
check internalABCICodespace also

Without this patch, all of the errors which has error code 1 changed to `internalABCILog`