### PR TITLE
feat: re-enable sig cache w/ skipping sig verify when rechecking

### DIFF
--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -737,7 +737,10 @@ func TestAnteHandlerReCheck(t *testing.T) {
 	app, ctx := createTestApp(true)
 	// set blockheight and recheck=true
 	ctx = ctx.WithBlockHeight(1)
-	ctx = ctx.WithIsReCheckTx(true)
+
+	checkCtx, _ := ctx.CacheContext()
+	recheckCtx, _ := ctx.CacheContext()
+	recheckCtx = recheckCtx.WithIsReCheckTx(true)
 
 	// keys and addresses
 	priv1, _, addr1 := types.KeyTestPubAddr()
@@ -760,18 +763,16 @@ func TestAnteHandlerReCheck(t *testing.T) {
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []uint64{0}, []uint64{0}
 	tx := types.NewTestTxWithMemo(ctx, msgs, privs, accnums, seqs, fee, "thisisatestmemo")
 
-	// make signature array empty which would normally cause ValidateBasicDecorator and SigVerificationDecorator fail
-	// since these decorators don't run on recheck, the tx should pass the antehandler
-	stdTx := tx.(types.StdTx)
-	stdTx.Signatures = []types.StdSignature{}
+	_, err := antehandler(checkCtx, tx, false)
+	require.Nil(t, err, "AnteHandler errored on check unexpectedly: %v", err)
 
-	_, err := antehandler(ctx, stdTx, false)
+	_, err = antehandler(recheckCtx, tx, false)
 	require.Nil(t, err, "AnteHandler errored on recheck unexpectedly: %v", err)
 
-	tx = types.NewTestTxWithMemo(ctx, msgs, privs, accnums, seqs, fee, "thisisatestmemo")
+	tx = types.NewTestTxWithMemo(recheckCtx, msgs, privs, accnums, seqs, fee, "thisisatestmemo")
 	txBytes, err := json.Marshal(tx)
 	require.Nil(t, err, "Error marshalling tx: %v", err)
-	ctx = ctx.WithTxBytes(txBytes)
+	recheckCtx = recheckCtx.WithTxBytes(txBytes)
 
 	// require that state machine param-dependent checking is still run on recheck since parameters can change between check and recheck
 	testCases := []struct {
@@ -784,31 +785,33 @@ func TestAnteHandlerReCheck(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		// set testcase parameters
-		app.AccountKeeper.SetParams(ctx, tc.params)
+		app.AccountKeeper.SetParams(recheckCtx, tc.params)
 
-		_, err := antehandler(ctx, tx, false)
+		_, err := antehandler(recheckCtx, tx, false)
 
 		require.NotNil(t, err, "tx does not fail on recheck with updated params in test case: %s", tc.name)
 
 		// reset parameters to default values
-		app.AccountKeeper.SetParams(ctx, types.DefaultParams())
+		app.AccountKeeper.SetParams(recheckCtx, types.DefaultParams())
 	}
 
 	// require that local mempool fee check is still run on recheck since validator may change minFee between check and recheck
 	// create new minimum gas price so antehandler fails on recheck
-	ctx = ctx.WithMinGasPrices([]sdk.DecCoin{{
+	recheckCtx = recheckCtx.WithMinGasPrices([]sdk.DecCoin{{
 		Denom:  "dnecoin", // fee does not have this denom
 		Amount: sdk.NewDec(5),
 	}})
-	_, err = antehandler(ctx, tx, false)
+
+	_, err = antehandler(recheckCtx, tx, false)
 	require.NotNil(t, err, "antehandler on recheck did not fail when mingasPrice was changed")
+
 	// reset min gasprice
-	ctx = ctx.WithMinGasPrices(sdk.DecCoins{})
+	recheckCtx = recheckCtx.WithMinGasPrices(sdk.DecCoins{})
 
 	// remove funds for account so antehandler fails on recheck
 	acc1.SetCoins(sdk.Coins{})
-	app.AccountKeeper.SetAccount(ctx, acc1)
+	app.AccountKeeper.SetAccount(recheckCtx, acc1)
 
-	_, err = antehandler(ctx, tx, false)
+	_, err = antehandler(recheckCtx, tx, false)
 	require.NotNil(t, err, "antehandler on recheck did not fail once feePayer no longer has sufficient funds")
 }

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -142,7 +142,7 @@ func TestSigVerification(t *testing.T) {
 		{"wrong accnums", []crypto.PrivKey{priv1, priv2, priv3}, []uint64{7, 8, 9}, []uint64{0, 0, 0}, false, true},
 		{"wrong sequences", []crypto.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{3, 4, 5}, false, true},
 		{"valid tx", []crypto.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}, false, false},
-		{"no err on recheck", []crypto.PrivKey{}, []uint64{}, []uint64{}, true, false},
+		{"no err on recheck", []crypto.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}, true, false},
 	}
 	for i, tc := range testCases {
 		ctx = ctx.WithIsReCheckTx(tc.recheck)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
re-enable sig cache w/ skipping sig verify when rechecking

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

