### PR TITLE
Use Voting Power from Validator.Power for distribution and slashing

### DIFF
--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -13,9 +13,9 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// determine the total power signing the block
 	var previousTotalPower, sumPreviousPrecommitPower int64
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		previousTotalPower += voteInfo.Validator.Power
+		previousTotalPower += voteInfo.VotingPower
 		if voteInfo.SignedLastBlock {
-			sumPreviousPrecommitPower += voteInfo.Validator.Power
+			sumPreviousPrecommitPower += voteInfo.VotingPower
 		}
 	}
 

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -88,7 +88,7 @@ func (k Keeper) AllocateTokens(
 
 		// TODO consider microslashing for missing votes.
 		// ref https://github.com/cosmos/cosmos-sdk/issues/2525#issuecomment-430838701
-		powerFraction := sdk.NewDec(vote.Validator.Power).QuoTruncate(sdk.NewDec(totalPreviousPower))
+		powerFraction := sdk.NewDec(vote.VotingPower).QuoTruncate(sdk.NewDec(totalPreviousPower))
 		reward := feesCollected.MulDecTruncate(voteMultiplier).MulDecTruncate(powerFraction)
 		k.AllocateTokensToValidator(ctx, validator, reward)
 		remaining = remaining.Sub(reward)

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -95,10 +95,12 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	votes := []abci.VoteInfo{
 		{
 			Validator:       abciValA,
+			VotingPower:     abciValA.Power,
 			SignedLastBlock: true,
 		},
 		{
 			Validator:       abciValB,
+			VotingPower:     abciValB.Power,
 			SignedLastBlock: true,
 		},
 	}
@@ -185,14 +187,17 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	votes := []abci.VoteInfo{
 		{
 			Validator:       abciValA,
+			VotingPower:     abciValA.Power,
 			SignedLastBlock: true,
 		},
 		{
 			Validator:       abciValB,
+			VotingPower:     abciValB.Power,
 			SignedLastBlock: true,
 		},
 		{
 			Validator:       abciValС,
+			VotingPower:     abciValС.Power,
 			SignedLastBlock: true,
 		},
 	}

--- a/x/evidence/internal/types/evidence.go
+++ b/x/evidence/internal/types/evidence.go
@@ -94,7 +94,7 @@ func (e Equivocation) GetTotalPower() int64 { return 0 }
 func ConvertDuplicateVoteEvidence(dupVote abci.Evidence) exported.Evidence {
 	return Equivocation{
 		Height:           dupVote.Height,
-		Power:            dupVote.Validator.Power,
+		Power:            dupVote.VotingPower,
 		ConsensusAddress: sdk.ConsAddress(dupVote.Validator.Address),
 		Time:             dupVote.Time,
 	}

--- a/x/simulation/mock_tendermint.go
+++ b/x/simulation/mock_tendermint.go
@@ -153,6 +153,7 @@ func RandomRequestBeginBlock(r *rand.Rand, params Params,
 				Address: pubkey.Address(),
 				Power:   mVal.val.Power,
 			},
+			VotingPower:     mVal.val.Power,
 			SignedLastBlock: signed,
 		}
 	}
@@ -185,7 +186,7 @@ func RandomRequestBeginBlock(r *rand.Rand, params Params,
 
 		var totalVotingPower int64
 		for _, val := range vals {
-			totalVotingPower += val.Validator.Power
+			totalVotingPower += val.VotingPower
 		}
 
 		evidence = append(evidence,

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -13,6 +13,6 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 	// store whether or not they have actually signed it and slash/unbond any
 	// which have missed too many blocks in a row (downtime slashing)
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		k.HandleValidatorSignature(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
+		k.HandleValidatorSignature(ctx, voteInfo.Validator.Address, voteInfo.VotingPower, voteInfo.SignedLastBlock)
 	}
 }

--- a/x/slashing/abci_test.go
+++ b/x/slashing/abci_test.go
@@ -41,6 +41,7 @@ func TestBeginBlocker(t *testing.T) {
 		LastCommitInfo: abci.LastCommitInfo{
 			Votes: []abci.VoteInfo{{
 				Validator:       val,
+				VotingPower:     val.Power,
 				SignedLastBlock: true,
 			}},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://github.com/line/link/issues/1111

## Description
<!--- Describe your changes in detail -->
I change the calculation of `slashing` and `distribution` to use `VotingPower` instead of `Validator.Power.`
## Motivation and context
The selection method of VoteSet and Proposer of line / tendemint has been changed. For this reason, I change the calculation of power on ditribution and slashing  to match the change using  `VotingPower`.
<!--- Why is this change required? What problem does it solve? -->
By using VotingPower, the value calculated by slashing / distribution is proportional to stakingPower.
<!--- If it fixes an open issue, please link to the issue here. -->

<!---  ## How has this been tested?-->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!---## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md). -->
<!--- - [ ] I have updated the documentation accordingly. -->
<!--- - [ ] I have added tests to cover my changes. -->


