### PR TITLE
chore: add mem-profile-rate config to app.toml

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -39,6 +40,10 @@ type BaseConfig struct {
 
 	// InterBlockCache enables inter-block caching.
 	InterBlockCache bool `mapstructure:"inter-block-cache"`
+
+	// MemProfileRate contains the value of runtime.MemProfileRate. (default 512 * 1024)
+	// When set to 0 memory profiling is disabled.
+	MemProfileRate int `mapstructure:"mem-profile-rate"`
 }
 
 // Config defines the server's top level configuration
@@ -83,6 +88,7 @@ func DefaultConfig() *Config {
 			PruningKeepRecent: "0",
 			PruningKeepEvery:  "0",
 			PruningInterval:   "0",
+			MemProfileRate:    runtime.MemProfileRate,
 		},
 	}
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -44,6 +44,10 @@ halt-time = {{ .BaseConfig.HaltTime }}
 
 # InterBlockCache enables inter-block caching.
 inter-block-cache = {{ .BaseConfig.InterBlockCache }}
+
+# MemProfileRate contains the value of runtime.MemProfileRate. (default 512 * 1024)
+# When set to 0 memory profiling is disabled.
+mem-profile-rate = {{ .BaseConfig.MemProfileRate }}
 `
 
 var configTemplate *template.Template


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #XXX

## Description
1. Add `mem-profile-rate` config to `app.toml`.
2. Add `mem-profile-rate` flags for `linkd start`

## Motivation and context
It should be possible to adjust the mem-profile-rate to avoid performance degradation during long-term execution.


## How has this been tested?
1. Checkout this PR and Apply this version to `link` using replace
```
# go.mod for link

....
replace github.com/cosmos/cosmos-sdk => ../cosmos-sdk
# replace github.com/cosmos/cosmos-sdk => {the path of your cosmos-sdk repo}
```

2. Initialize `link`
```
./.initialize.sh
```

3. Check if `mem-profile-rate` is in `app.toml`.

```
cat ~/.linkd/config/app.toml 

...
# MemProfileRate contains the value of runtime.MemProfileRate. (default 512 * 1024)
# When set to 0 memory profiling is disabled.
mem-profile-rate = 524288
```

4. Fix `mem-profile-rate` in `app.toml`.
```
vim ~/.linkd/config/app.toml 

...
mem-profile-rate = 0
```

5. Start linkd and check `MemProfileRate`
```
linkd start

I[2020-12-07|18:19:51.094] Network mode is mainnet                      module=main 
I[2020-12-07|18:19:51.094] LINK DB Backend is goleveldb                 module=main 
I[2020-12-07|18:19:51.094] Tendermint DB Backend is goleveldb           module=main 
I[2020-12-07|18:19:51.094] MemProfileRate is 0                          module=main 
I[2020-12-07|18:19:51.094] starting ABCI with Tendermint                module=main
```

6. Start linkd with `mem-profile-rate` flag and check `MemProfileRate`
```
linkd start --mem-profile-rate=1234
                          
I[2020-12-07|18:20:55.505] Network mode is mainnet                      module=main 
I[2020-12-07|18:20:55.505] LINK DB Backend is goleveldb                 module=main 
I[2020-12-07|18:20:55.505] Tendermint DB Backend is goleveldb           module=main 
I[2020-12-07|18:20:55.505] MemProfileRate is 1234                       module=main 
I[2020-12-07|18:20:55.505] starting ABCI with Tendermint                module=main 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

