### PR TITLE
fix: fix to not skip sigverify when recheck

### DIFF
--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -174,11 +174,6 @@ func NewSigVerificationDecorator(ak keeper.AccountKeeper) *SigVerificationDecora
 }
 
 func (svd *SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	// TODO https://github.com/line/link/issues/1136
-	// no need to verify signatures on recheck tx
-	if ctx.IsReCheckTx() {
-		return next(ctx, tx, simulate)
-	}
 	sigTx, ok := tx.(SigVerifiableTx)
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")


### PR DESCRIPTION
Related https://github.com/line/link/issues/1214

## Description
- fix to not skip sigverify when recheck

## Motivation and context
We should fix a bug not to increase sequence if the tx is not valid.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

