### PR TITLE
test: add test whether pubkey is generated with composite type or not

### DIFF
--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	abciServer "github.com/tendermint/tendermint/abci/server"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"github.com/tendermint/tendermint/crypto/composite"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -132,7 +135,8 @@ func TestInitNodeValidatorFiles(t *testing.T) {
 	nodeID, valPubKey, err := genutil.InitializeNodeValidatorFiles(cfg)
 	require.Nil(t, err)
 	require.NotEqual(t, "", nodeID)
-	require.NotEqual(t, 0, len(valPubKey.Bytes()))
+	require.Equal(t, 37, len(valPubKey.Bytes()))
+	require.EqualValues(t, reflect.TypeOf(ed25519.PubKeyEd25519{}), reflect.TypeOf(valPubKey))
 }
 
 func TestInitNodeValidatorFilesWithComposite(t *testing.T) {
@@ -147,7 +151,8 @@ func TestInitNodeValidatorFilesWithComposite(t *testing.T) {
 	nodeID, valPubKey, err := genutil.InitializeNodeValidatorFiles(cfg)
 	require.Nil(t, err)
 	require.NotEqual(t, "", nodeID)
-	require.NotEqual(t, 0, len(valPubKey.Bytes()))
+	require.Equal(t, 90, len(valPubKey.Bytes()))
+	require.EqualValues(t, reflect.TypeOf(composite.PubKeyComposite{}), reflect.TypeOf(valPubKey))
 }
 
 // custom tx codec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #XXX

## Description
<!--- Describe your changes in detail -->
Since I added a flag that can specify the type of pubkey, I will add test whether it can be created with the specified pubkey type.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The function that can specify the type of pubkey and their flag.
See:
#43 
https://github.com/line/tendermint/pull/125
https://github.com/line/link/issues/1111

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- ~[ ] I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.

