### PR TITLE
fix: add label as needed parameter for instantiate via REST

### DIFF
--- a/x/wasm/client/rest/tx.go
+++ b/x/wasm/client/rest/tx.go
@@ -33,6 +33,7 @@ type instantiateContractReq struct {
 	Deposit sdk.Coins      `json:"deposit" yaml:"deposit"`
 	Admin   sdk.AccAddress `json:"admin,omitempty" yaml:"admin"`
 	InitMsg []byte         `json:"init_msg" yaml:"init_msg"`
+	Label   string         `json:"label" yaml:"label"`
 }
 
 type executeContractReq struct {
@@ -116,6 +117,7 @@ func instantiateContractHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		msg := types.MsgInstantiateContract{
 			Sender:    cliCtx.GetFromAddress(),
 			CodeID:    codeID,
+			Label:     req.Label,
 			InitFunds: req.Deposit,
 			InitMsg:   req.InitMsg,
 			Admin:     req.Admin,


### PR DESCRIPTION
## Description
Add `label` as a needed parameter for instantiating a contract via REST

closes: #120 

---
This is not be tested. This endpoint will be abolished or published after being tested.