### PR TITLE
fix: Test_runImportCmd()

### DIFF
--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -2,7 +2,6 @@ package keys
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/line/lbm-sdk/v2/client"
-	"github.com/line/lbm-sdk/v2/client/flags"
 	"github.com/line/lbm-sdk/v2/crypto/keyring"
 	"github.com/line/lbm-sdk/v2/testutil"
 	sdk "github.com/line/lbm-sdk/v2/types"
@@ -46,9 +44,6 @@ HbP+c6JmeJy9JXe2rbbF1QtCX1gLqGcDQPBXiCtFvP7/8wTZtVOPj8vREzhZ9ElO
 	require.NoError(t, ioutil.WriteFile(keyfile, []byte(armoredKey), 0644))
 
 	mockIn.Reset("123456789\n")
-	cmd.SetArgs([]string{
-		"keyname1", keyfile,
-		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
-	})
+	cmd.SetArgs([]string{"keyname1", keyfile})
 	require.NoError(t, cmd.ExecuteContext(ctx))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

* fix `Test_runImportCmd()`.
* It's success only first time but failed after second execution.
* W/ CI environment, it's not issue because it's executed always w/ fresh docker container.

## The reason why it's failed.

* If we set `FlagKeyringBackend`, the keyring is overwritten by cmd.
* If keyring is overwritten, the keyring uses `home/keyring...` dir but not a temp dir.
* It fails to delete a test key because the keyring for test is overwritten.
* So, after second execution, it fails due there is already same key.

## Reference
https://github.com/line/lbm-sdk/blob/c508498905f249c39ce36ca3c45949546dcafb63/client/cmd.go#L119-L130

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
