### PR TITLE
feat: add prometheus metrics for caches reverting telemetry metrics

### DIFF
--- a/baseapp/options_test.go
+++ b/baseapp/options_test.go
@@ -1,0 +1,22 @@
+package baseapp
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsProvider(t *testing.T) {
+	p1, p2 := MetricsProvider(true)
+	c1 := p1()
+	c2 := p2()
+	require.NotEqual(t, c1.InterBlockCacheHits, discard.NewCounter())
+	require.NotEqual(t, c2.IAVLCacheHits, discard.NewGauge())
+
+	p1, p2 = MetricsProvider(false)
+	c1 = p1()
+	c2 = p2()
+	require.Equal(t, c1.InterBlockCacheHits, discard.NewCounter())
+	require.Equal(t, c2.IAVLCacheHits, discard.NewGauge())
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -73,6 +73,10 @@ type BaseConfig struct {
 
 	// IAVL cache size; bytes size unit
 	IAVLCacheSize int `mapstructure:"iavl-cache-size"`
+
+	// When true, Prometheus metrics are served under /metrics on prometheus_listen_addr in config.toml.
+	// It works when tendermint's prometheus option (config.toml) is set to true.
+	Prometheus bool `mapstructure:"prometheus"`
 }
 
 // APIConfig defines the API listener configuration.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -76,6 +76,10 @@ iavl-cache-size = {{ .BaseConfig.IAVLCacheSize }}
 # ["message.sender", "message.recipient"]
 index-events = {{ .BaseConfig.IndexEvents }}
 
+# When true, Prometheus metrics are served under /metrics on prometheus_listen_addr in config.toml.
+# It works when tendermint's prometheus option (config.toml) is set to true.
+prometheus = {{ .BaseConfig.Prometheus }}
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/server/start.go
+++ b/server/start.go
@@ -160,6 +160,8 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().Uint64(FlagStateSyncSnapshotInterval, 0, "State sync snapshot interval")
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
+	cmd.Flags().Bool(FlagPrometheus, false, "Enable prometheus metric for app")
+
 	// add support for all Ostracon-specific command line options
 	ostcmd.AddNodeFlags(cmd)
 	return cmd

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -54,7 +54,8 @@ func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
 // interBlockCacheOpt returns a BaseApp option function that sets the persistent
 // inter-block write-through cache.
 func interBlockCacheOpt() func(*baseapp.BaseApp) {
-	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize))
+	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager(
+		cache.DefaultCommitKVStoreCacheSize, cache.NopMetricsProvider()))
 }
 
 func TestFullAppSimulation(t *testing.T) {

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -6,6 +6,13 @@ import (
 	"os"
 	"path/filepath"
 
+	ostcli "github.com/line/ostracon/libs/cli"
+	"github.com/line/ostracon/libs/log"
+	tmdb "github.com/line/tm-db/v2"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/line/lbm-sdk/v2/baseapp"
 	"github.com/line/lbm-sdk/v2/client"
 	"github.com/line/lbm-sdk/v2/client/debug"
@@ -26,11 +33,6 @@ import (
 	banktypes "github.com/line/lbm-sdk/v2/x/bank/types"
 	"github.com/line/lbm-sdk/v2/x/crisis"
 	genutilcli "github.com/line/lbm-sdk/v2/x/genutil/client/cli"
-	ostcli "github.com/line/ostracon/libs/cli"
-	"github.com/line/ostracon/libs/log"
-	tmdb "github.com/line/tm-db/v2"
-	"github.com/spf13/cast"
-	"github.com/spf13/cobra"
 )
 
 // NewRootCmd creates a new root command for simd. It is called once in the
@@ -156,9 +158,11 @@ type appCreator struct {
 func (a appCreator) newApp(logger log.Logger, db tmdb.DB, traceStore io.Writer, appOpts servertypes.AppOptions) servertypes.Application {
 	var cache sdk.MultiStorePersistentCache
 
+	ibCacheMetricsProvider, iavlCacheMetricsProvider :=
+		baseapp.MetricsProvider(cast.ToBool(viper.GetBool(server.FlagPrometheus)))
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
 		cache = store.NewCommitKVStoreCacheManager(
-			cast.ToInt(appOpts.Get(server.FlagInterBlockCacheSize)))
+			cast.ToInt(appOpts.Get(server.FlagInterBlockCacheSize)), ibCacheMetricsProvider)
 	}
 
 	skipUpgradeHeights := make(map[int64]bool)
@@ -192,10 +196,10 @@ func (a appCreator) newApp(logger log.Logger, db tmdb.DB, traceStore io.Writer, 
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
-		baseapp.SetIAVLCacheManager(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
 		baseapp.SetInterBlockCache(cache),
-		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
+		baseapp.SetIAVLCacheManager(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize)), iavlCacheMetricsProvider),
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
+		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),

--- a/store/cache/cache_test.go
+++ b/store/cache/cache_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetOrSetStoreCache(t *testing.T) {
 	db := memdb.NewDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, cache.NopMetricsProvider())
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100)
@@ -30,7 +30,7 @@ func TestGetOrSetStoreCache(t *testing.T) {
 
 func TestUnwrap(t *testing.T) {
 	db := memdb.NewDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, cache.NopMetricsProvider())
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100)
@@ -44,7 +44,7 @@ func TestUnwrap(t *testing.T) {
 
 func TestStoreCache(t *testing.T) {
 	db := memdb.NewDB()
-	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
+	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize, cache.NopMetricsProvider())
 
 	sKey := types.NewKVStoreKey("test")
 	tree, err := iavl.NewMutableTree(db, 100)

--- a/store/cache/metrics.go
+++ b/store/cache/metrics.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
+	// package.
+	MetricsSubsystem = "inter_block_cache"
+)
+
+// Metrics contains metrics exposed by this package.
+type Metrics struct {
+	InterBlockCacheHits    metrics.Counter
+	InterBlockCacheMisses  metrics.Counter
+	InterBlockCacheEntries metrics.Gauge
+	InterBlockCacheBytes   metrics.Gauge
+}
+
+// PrometheusMetrics returns Metrics build using Prometheus client library.
+// Optionally, labels can be provided along with their values ("foo",
+// "fooValue").
+func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
+	labels := []string{}
+	for i := 0; i < len(labelsAndValues); i += 2 {
+		labels = append(labels, labelsAndValues[i])
+	}
+	return &Metrics{
+		InterBlockCacheHits: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "hits",
+			Help:      "Cache hits of the inter block cache",
+		}, labels).With(labelsAndValues...),
+		InterBlockCacheMisses: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "misses",
+			Help:      "Cache misses of the inter block cache",
+		}, labels).With(labelsAndValues...),
+		InterBlockCacheEntries: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "entries",
+			Help:      "Cache entry count of the inter block cache",
+		}, labels).With(labelsAndValues...),
+		InterBlockCacheBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "bytes_size",
+			Help:      "Cache bytes size of the inter block cache",
+		}, labels).With(labelsAndValues...),
+	}
+}
+
+// NopMetrics returns no-op Metrics.
+func NopMetrics() *Metrics {
+	return &Metrics{
+		InterBlockCacheHits:    discard.NewCounter(),
+		InterBlockCacheMisses:  discard.NewCounter(),
+		InterBlockCacheEntries: discard.NewGauge(),
+		InterBlockCacheBytes:   discard.NewGauge(),
+	}
+}
+
+type MetricsProvider func() *Metrics
+
+// PrometheusMetricsProvider returns PrometheusMetrics for each store
+func PrometheusMetricsProvider(namespace string, labelsAndValues ...string) func() *Metrics {
+	return func() *Metrics {
+		return PrometheusMetrics(namespace, labelsAndValues...)
+	}
+}
+
+// NopMetricsProvider returns NopMetrics for each store
+func NopMetricsProvider() func() *Metrics {
+	return func() *Metrics {
+		return NopMetrics()
+	}
+}

--- a/store/cache/metrics_test.go
+++ b/store/cache/metrics_test.go
@@ -1,0 +1,16 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusMetrics(t *testing.T) {
+	metrics := PrometheusMetrics("test")
+	require.NotEqual(t, metrics.InterBlockCacheHits, discard.NewCounter())
+	require.NotEqual(t, metrics.InterBlockCacheMisses, discard.NewCounter())
+	require.NotEqual(t, metrics.InterBlockCacheEntries, discard.NewGauge())
+	require.NotEqual(t, metrics.InterBlockCacheBytes, discard.NewGauge())
+}

--- a/store/iavl/metrics.go
+++ b/store/iavl/metrics.go
@@ -1,0 +1,84 @@
+package iavl
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
+	// package.
+	MetricsSubsystem = "iavl_cache"
+)
+
+// Metrics contains metrics exposed by this package.
+type Metrics struct {
+	IAVLCacheHits    metrics.Gauge
+	IAVLCacheMisses  metrics.Gauge
+	IAVLCacheEntries metrics.Gauge
+	IAVLCacheBytes   metrics.Gauge
+}
+
+// PrometheusMetrics returns Metrics build using Prometheus client library.
+// Optionally, labels can be provided along with their values ("foo",
+// "fooValue").
+func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
+	labels := []string{}
+	for i := 0; i < len(labelsAndValues); i += 2 {
+		labels = append(labels, labelsAndValues[i])
+	}
+	return &Metrics{
+		IAVLCacheHits: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "hits",
+			Help:      "Cache hit count of the iavl cache",
+		}, labels).With(labelsAndValues...),
+		IAVLCacheMisses: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "misses",
+			Help:      "Cache miss count of the iavl cache",
+		}, labels).With(labelsAndValues...),
+		IAVLCacheEntries: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "entries",
+			Help:      "Cache entry count of the iavl cache",
+		}, labels).With(labelsAndValues...),
+		IAVLCacheBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "bytes_size",
+			Help:      "Cache bytes size of the iavl cache",
+		}, labels).With(labelsAndValues...),
+	}
+}
+
+// NopMetrics returns no-op Metrics.
+func NopMetrics() *Metrics {
+	return &Metrics{
+		IAVLCacheHits:    discard.NewGauge(),
+		IAVLCacheMisses:  discard.NewGauge(),
+		IAVLCacheEntries: discard.NewGauge(),
+		IAVLCacheBytes:   discard.NewGauge(),
+	}
+}
+
+type MetricsProvider func() *Metrics
+
+// PrometheusMetricsProvider returns PrometheusMetrics for each store
+func PrometheusMetricsProvider(namespace string, labelsAndValues ...string) func() *Metrics {
+	return func() *Metrics {
+		return PrometheusMetrics(namespace, labelsAndValues...)
+	}
+}
+
+// NopMetricsProvider returns NopMetrics for each store
+func NopMetricsProvider() func() *Metrics {
+	return func() *Metrics {
+		return NopMetrics()
+	}
+}

--- a/store/iavl/metrics_test.go
+++ b/store/iavl/metrics_test.go
@@ -1,0 +1,16 @@
+package iavl
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusMetrics(t *testing.T) {
+	metrics := PrometheusMetrics("test")
+	require.NotEqual(t, metrics.IAVLCacheHits, discard.NewGauge())
+	require.NotEqual(t, metrics.IAVLCacheMisses, discard.NewGauge())
+	require.NotEqual(t, metrics.IAVLCacheEntries, discard.NewGauge())
+	require.NotEqual(t, metrics.IAVLCacheBytes, discard.NewGauge())
+}

--- a/store/store.go
+++ b/store/store.go
@@ -12,6 +12,6 @@ func NewCommitMultiStore(db tmdb.DB) types.CommitMultiStore {
 	return rootmulti.NewStore(db)
 }
 
-func NewCommitKVStoreCacheManager(cacheSize int) types.MultiStorePersistentCache {
-	return cache.NewCommitKVStoreCacheManager(cacheSize)
+func NewCommitKVStoreCacheManager(cacheSize int, metricsProvider cache.MetricsProvider) types.MultiStorePersistentCache {
+	return cache.NewCommitKVStoreCacheManager(cacheSize, metricsProvider)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
We found that telemetry has serious performance-degradation problem. (1000 tps -> 600 tps on a single node)
This PR reverts telemetry feature and adds prometheus metrics for caches.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
