### PR TITLE
fix: increate minimum limit of randomly generated sig block period

### DIFF
--- a/x/auth/simulation/genesis.go
+++ b/x/auth/simulation/genesis.go
@@ -89,8 +89,8 @@ func GenSigVerifyCostSECP256K1(r *rand.Rand) uint64 {
 }
 
 func GenValidSigBlockPeriod(r *rand.Rand) uint64 {
-	// We use valid sig block period greater than 100 for testing
-	return uint64(simulation.RandIntBetween(r, 100, 1000))
+	// We use valid sig block period greater than 500 for testing (to include test-sim-multi-seed-long 500 blocks)
+	return uint64(simulation.RandIntBetween(r, 501, 10000))
 }
 
 // RandomizedGenState generates a random GenesisState for auth


### PR DESCRIPTION
rc0/v0.1.0 branch failed on `test-sim-multi-seed-long` because too small sig block height for long block length(500).
I increase minimum limit of randomly generated sig block period for sim test.