### PR TITLE
chore: increase default valid_sig_block_period

### DIFF
--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -160,7 +160,7 @@ func (suite *AnteTestSuite) TestAnteHandlerSigErrors() {
 func (suite *AnteTestSuite) TestAnteHandlerSigBlockHeight() {
 	suite.SetupTest(false) // reset
 
-	suite.ctx = suite.ctx.WithBlockHeight(20000) // init block height is 200
+	suite.ctx = suite.ctx.WithBlockHeight(5000) // init block height is 5000
 
 	// Same data for every test cases
 	accounts := suite.CreateTestAccounts(2)
@@ -182,7 +182,7 @@ func (suite *AnteTestSuite) TestAnteHandlerSigBlockHeight() {
 				msg := testdata.NewTestMsg(accounts[0].acc.GetAddress())
 				msgs = []sdk.Msg{msg}
 
-				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv}, []uint64{10000}, []uint64{0}
+				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv}, []uint64{3600}, []uint64{0}
 			},
 			false,
 			true,
@@ -200,7 +200,7 @@ func (suite *AnteTestSuite) TestAnteHandlerSigBlockHeight() {
 		{
 			"new tx from correct sig block height",
 			func() {
-				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv}, []uint64{10000}, []uint64{1}
+				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv}, []uint64{3600}, []uint64{1}
 			},
 			false,
 			true,
@@ -221,7 +221,7 @@ func (suite *AnteTestSuite) TestAnteHandlerSigBlockHeight() {
 		{
 			"new tx with correct sig block height",
 			func() {
-				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv, accounts[1].priv}, []uint64{10000, 10001}, []uint64{2, 0}
+				privs, sbh, accSeqs = []cryptotypes.PrivKey{accounts[0].priv, accounts[1].priv}, []uint64{3600, 3601}, []uint64{2, 0}
 			},
 			false,
 			true,

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -15,7 +15,7 @@ const (
 	DefaultTxSizeCostPerByte      uint64 = 10
 	DefaultSigVerifyCostED25519   uint64 = 590
 	DefaultSigVerifyCostSecp256k1 uint64 = 1000
-	DefaultValidSigBlockPeriod    uint64 = 10000
+	DefaultValidSigBlockPeriod    uint64 = 3600 // 1 hour for 1 second block interval
 )
 
 // Parameter keys


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Currently, default valid_sig_block_period is 100 and this value is too small.
If we set block interval to 1 second, then after 1 minute and 40 seconds of signing, tx becomes an invalid state.
In reality, this state makes the test of vulcan fail.
We increase this up to 10000.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
