### PR TITLE
feat: async store pruning 

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1,17 +1,23 @@
 package baseapp
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	iavltree "github.com/line/iavl/v2"
 	abci "github.com/line/ostracon/abci/types"
+	"github.com/line/ostracon/libs/log"
 	ocproto "github.com/line/ostracon/proto/ostracon/types"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -326,6 +332,9 @@ func (app *BaseApp) Commit() (res abci.ResponseCommit) {
 	app.deliverState.ms.Write()
 	commitID := app.cms.Commit()
 	app.logger.Info("commit synced", "commit", fmt.Sprintf("%X", commitID))
+
+	// iavl, db & disk stats
+	logIoStats(app.logger)
 
 	// empty/reset the deliver state
 	app.deliverState = nil
@@ -900,4 +909,101 @@ func splitPath(requestPath string) (path []string) {
 	}
 
 	return path
+}
+
+// log iavl, db & disk stats if IAVL_DEV env. var. is set
+var (
+	logIoDev                                                     string
+	tStats                                                       time.Time
+	iavlSetCount, iavlSetBytes, iavlDelCount                     uint64
+	diskReadCount, diskReadBytes, diskWriteCount, diskWriteBytes uint64
+)
+
+// read disk io stats from /proc/diskstats in linux
+func getDeviceIoStats(device string) (readCount, readBytes, writeCount, writeBytes uint64, err error) {
+	inf, err := os.Open("/proc/diskstats")
+	if err != nil {
+		return
+	}
+	defer inf.Close()
+
+	in := bufio.NewReader(inf)
+	r := regexp.MustCompile(`\s+`)
+	for {
+		line, err2 := in.ReadString('\n')
+		if err2 != nil {
+			if err2 == io.EOF {
+				break
+			}
+			err = err2
+			return
+		}
+		parts := r.Split(strings.TrimSpace(line), -1)
+		if len(parts) < 10 {
+			continue
+		}
+		if len(device) > 0 && device != parts[2] {
+			continue
+		} else if len(device) == 0 && parts[1] != "0" {
+			continue
+		}
+
+		rCount, e1 := strconv.ParseUint(parts[3], 10, 64)
+		rSectors, e2 := strconv.ParseUint(parts[5], 10, 64)
+		wCount, e3 := strconv.ParseUint(parts[7], 10, 64)
+		wSectors, e4 := strconv.ParseUint(parts[9], 10, 64)
+		if e1 != nil || e2 != nil || e3 != nil || e4 != nil {
+			continue
+		}
+
+		readCount += rCount
+		readBytes += rSectors * 512
+		writeCount += wCount
+		writeBytes += wSectors * 512
+	}
+	return readCount, readBytes, writeCount, writeBytes, err
+}
+
+func logIoStats(logger log.Logger) {
+	if len(logIoDev) == 0 {
+		// not set yet
+		if dev := os.Getenv("IAVL_DEV"); len(dev) >= 0 {
+			logIoDev = dev
+		} else {
+			logIoDev = " nop"
+			return
+		}
+	} else if logIoDev == " nop" {
+		return
+	}
+
+	now := time.Now()
+	dt := now.Sub(tStats)
+	tStats = now
+
+	newSetCount, newSetBytes, newDelCount := iavltree.GetDBStats()
+	newReadCount, newReadBytes, newWriteCount, newWriteBytes, _ := getDeviceIoStats(logIoDev)
+	diffSetCount, diffSetBytes, diffDelCount := newSetCount-iavlSetCount, newSetBytes-iavlSetBytes, newDelCount-iavlDelCount
+	_, diffReadBytes, _, diffWriteBytes := newReadCount-diskReadCount, newReadBytes-diskReadBytes, newWriteCount-diskWriteCount, newWriteBytes-diskWriteBytes
+	iavlSetCount, iavlSetBytes, iavlDelCount = newSetCount, newSetBytes, newDelCount
+	diskReadCount, diskReadBytes, diskWriteCount, diskWriteBytes = newReadCount, newReadBytes, newWriteCount, newWriteBytes
+
+	// read & write bytes per second
+	rps, wps := int64(0), int64(0)
+	if dt.Milliseconds() > 0 && dt.Seconds() < 1000 {
+		rps = int64(diffReadBytes) * 1000 / dt.Milliseconds()
+		wps = int64(diffWriteBytes) * 1000 / dt.Milliseconds()
+	}
+
+	// write amplification factors
+	wampf := float64(0)
+	if diffSetBytes > 0 {
+		wampf = float64(diffWriteBytes*1000/diffSetBytes) / 1000.0
+	}
+
+	logger.Info("io_stats", "set_count", diffSetCount,
+		"set_bytes", diffSetBytes, "del_count", diffDelCount,
+		"read-bytes", diffReadBytes, "rps", rps,
+		"write_bytes", diffWriteBytes, "wps", wps,
+		"write_amp_f", wampf, "ellapsed", float64(dt.Milliseconds())/1000.0)
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -60,6 +60,9 @@ type Store struct {
 
 	interBlockCache  types.MultiStorePersistentCache
 	iavlCacheManager types.CacheManager
+
+	pruneLock *sync.Mutex
+	prunePass chan bool
 }
 
 var (
@@ -79,6 +82,8 @@ func NewStore(db tmdb.DB) *Store {
 		stores:       make(map[types.StoreKey]types.CommitKVStore),
 		keysByName:   make(map[string]types.StoreKey),
 		pruneHeights: make([]int64, 0),
+		pruneLock:    &sync.Mutex{},
+		prunePass:    make(chan bool, 1),
 	}
 }
 
@@ -365,7 +370,7 @@ func (rs *Store) Commit() types.CommitID {
 
 	// batch prune if the current height is a pruning interval height
 	if rs.pruningOpts.Interval > 0 && version%int64(rs.pruningOpts.Interval) == 0 {
-		rs.pruneStores()
+		go rs.pruneStores()
 	}
 
 	flushMetadata(rs.db, version, rs.lastCommitInfo, rs.pruneHeights)
@@ -376,10 +381,32 @@ func (rs *Store) Commit() types.CommitID {
 	}
 }
 
+func (rs *Store) prunePassEnter() bool {
+	select {
+	case rs.prunePass <- true:
+		return true
+	default:
+		return false
+	}
+}
+
+func (rs *Store) prunePassLeave() {
+	<-rs.prunePass
+}
+
 // pruneStores will batch delete a list of heights from each mounted sub-store.
 // Afterwards, pruneHeights is reset.
 func (rs *Store) pruneStores() {
-	if len(rs.pruneHeights) == 0 {
+	if !rs.prunePassEnter() {
+		return
+	}
+	defer rs.prunePassLeave()
+
+	rs.pruneLock.Lock()
+	pruneHeights := make([]int64, len(rs.pruneHeights))
+	copy(pruneHeights, rs.pruneHeights)
+	rs.pruneLock.Unlock()
+	if len(pruneHeights) == 0 {
 		return
 	}
 
@@ -389,7 +416,7 @@ func (rs *Store) pruneStores() {
 			// it to get the underlying IAVL store.
 			store = rs.GetCommitKVStore(key)
 
-			if err := store.(*iavl.Store).DeleteVersions(rs.pruneHeights...); err != nil {
+			if err := store.(*iavl.Store).DeleteVersions(pruneHeights...); err != nil {
 				if errCause := errors.Cause(err); errCause != nil && errCause != iavltree.ErrVersionDoesNotExist {
 					panic(err)
 				}
@@ -397,7 +424,21 @@ func (rs *Store) pruneStores() {
 		}
 	}
 
-	rs.pruneHeights = make([]int64, 0)
+	// remove pruned heights from rs.pruneHeights
+	// new rs.pruneHeights will be updated by next flushMedataData cycle
+	rs.pruneLock.Lock()
+	rph := map[int64]bool{}
+	for _, h := range pruneHeights {
+		rph[h] = true
+	}
+	nph := make([]int64, 0, len(rs.pruneHeights))
+	for _, h := range rs.pruneHeights {
+		if _, ok := rph[h]; !ok {
+			nph = append(nph, h)
+		}
+	}
+	rs.pruneHeights = nph
+	rs.pruneLock.Unlock()
 }
 
 // CacheWrap implements CacheWrapper/Store/CommitStore.

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -533,6 +534,8 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 
 	// commit one more block and ensure the heights have been pruned
 	ms.Commit()
+	// pruning is background job, sleeps for a few seconds for the pruning to finish
+	time.Sleep(5 * time.Second)
 	require.Empty(t, ms.pruneHeights)
 
 	for _, v := range pruneHeights {


### PR DESCRIPTION
Made store pruning background process, so that it won't get in the way of block generation.

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
