### PR TITLE
feat: change wasm metrics method

### DIFF
--- a/x/wasm/keeper/metrics.go
+++ b/x/wasm/keeper/metrics.go
@@ -98,10 +98,10 @@ type metricSource interface {
 	GetMetrics() (*wasmvmtypes.Metrics, error)
 }
 
-var _ prometheus.Collector = (*WasmVMMetricsCollector)(nil)
+var _ prometheus.Collector = (*WasmVMCacheMetricsCollector)(nil)
 
-// WasmVMMetricsCollector custom metrics collector to be used with Prometheus
-type WasmVMMetricsCollector struct {
+// WasmVMCacheMetricsCollector custom metrics collector to be used with Prometheus
+type WasmVMCacheMetricsCollector struct {
 	source             metricSource
 	CacheHitsDescr     *prometheus.Desc
 	CacheMissesDescr   *prometheus.Desc
@@ -109,9 +109,9 @@ type WasmVMMetricsCollector struct {
 	CacheSizeDescr     *prometheus.Desc
 }
 
-//NewWasmVMMetricsCollector constructor
-func NewWasmVMMetricsCollector(s metricSource) *WasmVMMetricsCollector {
-	return &WasmVMMetricsCollector{
+//NewWasmVMCacheMetricsCollector constructor
+func NewWasmVMCacheMetricsCollector(s metricSource) *WasmVMCacheMetricsCollector {
+	return &WasmVMCacheMetricsCollector{
 		source:             s,
 		CacheHitsDescr:     prometheus.NewDesc("wasmvm_cache_hits_total", "Total number of cache hits", []string{"type"}, nil),
 		CacheMissesDescr:   prometheus.NewDesc("wasmvm_cache_misses_total", "Total number of cache misses", nil, nil),
@@ -121,12 +121,12 @@ func NewWasmVMMetricsCollector(s metricSource) *WasmVMMetricsCollector {
 }
 
 // Register registers all metrics
-func (p *WasmVMMetricsCollector) Register(r prometheus.Registerer) {
+func (p *WasmVMCacheMetricsCollector) Register(r prometheus.Registerer) {
 	r.MustRegister(p)
 }
 
 // Describe sends the super-set of all possible descriptors of metrics
-func (p *WasmVMMetricsCollector) Describe(descs chan<- *prometheus.Desc) {
+func (p *WasmVMCacheMetricsCollector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- p.CacheHitsDescr
 	descs <- p.CacheMissesDescr
 	descs <- p.CacheElementsDescr
@@ -134,7 +134,7 @@ func (p *WasmVMMetricsCollector) Describe(descs chan<- *prometheus.Desc) {
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
-func (p *WasmVMMetricsCollector) Collect(c chan<- prometheus.Metric) {
+func (p *WasmVMCacheMetricsCollector) Collect(c chan<- prometheus.Metric) {
 	m, err := p.source.GetMetrics()
 	if err != nil {
 		return

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -82,3 +82,9 @@ func WithVMCacheMetrics(r prometheus.Registerer) Option {
 		NewWasmVMMetricsCollector(k.wasmVM).Register(r)
 	})
 }
+
+func WithVMMetrics(provider MetricsProvider) Option {
+	return optsFn(func(k *Keeper) {
+		k.metrics = provider()
+	})
+}

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -79,7 +79,7 @@ func WithCoinTransferrer(x CoinTransferrer) Option {
 
 func WithVMCacheMetrics(r prometheus.Registerer) Option {
 	return optsFn(func(k *Keeper) {
-		NewWasmVMMetricsCollector(k.wasmVM).Register(r)
+		NewWasmVMCacheMetricsCollector(k.wasmVM).Register(r)
 	})
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #357

The metrics method for observing the wasm was the telemetry.
However, telemetry had performance degradation issues.
Change the method to use prometheus directly. In testing, this did not cause any performance degradation.

In addition to telemetry, wasm already had prometheus metrics for observing the cache of the VM internal implementation.
However, the observation method between our need and exist cache metrics is different .
Existing cache metrics are periodic observation by subscription of prometheus collector,
What we want is to happen at a point in time that run.

So add a new structure without refactoring the existing cache metrics.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
