### PR TITLE
fix: force genOrBroadcastFn even when max-msgs != 0

### DIFF
--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -53,13 +53,12 @@ func newSplitAndApply(
 	genOrBroadcastFn newGenerateOrBroadcastFunc, clientCtx client.Context,
 	fs *pflag.FlagSet, msgs []sdk.Msg, chunkSize int,
 ) error {
-
-	if chunkSize == 0 {
+	totalMessages := len(msgs)
+	if chunkSize == 0 || totalMessages == 0 {
 		return genOrBroadcastFn(clientCtx, fs, msgs...)
 	}
 
 	// split messages into slices of length chunkSize
-	totalMessages := len(msgs)
 	for i := 0; i < len(msgs); i += chunkSize {
 
 		sliceEnd := i + chunkSize

--- a/x/distribution/client/cli/tx_test.go
+++ b/x/distribution/client/cli/tx_test.go
@@ -21,8 +21,19 @@ import (
 func Test_splitAndCall_NoMessages(t *testing.T) {
 	clientCtx := client.Context{}
 
-	err := newSplitAndApply(nil, clientCtx, nil, nil, 10)
-	assert.NoError(t, err, "")
+	// empty tx will always trigger genOrBroadcastFn
+	maxMsgsCases := []int{0, 1, 10}
+	calledCounter := 0
+	for _, maxMsgs := range maxMsgsCases {
+		err := newSplitAndApply(
+			func(clientCtx client.Context, fs *pflag.FlagSet, msgs ...sdk.Msg) error {
+				// dummy genOrBroadcastFn called once for each case
+				calledCounter++
+				return nil
+			}, clientCtx, nil, nil, maxMsgs)
+		assert.NoError(t, err, "")
+	}
+	assert.Equal(t, calledCounter, len(maxMsgsCases))
 }
 
 func Test_splitAndCall_Splitting(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

If cli tx withdraw-all-rewards sends empty tx, the tx would be
rejected by validators because it has no msgs. However, the cli sends
empty tx only if one sets `--max-msgs=0` which means it does not split
the msgs. When you set `max-msgs` with any positive number, the cli
does not send any tx, which may confuse you because you cannot get the
feedback indicating the address has no delegations.
This patch addresses the problem, by forcing genOrBroadcastFn when the
number of total msgs generated is zero. It will provide the same user
experience with any `max-msgs`.

closes: #363 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
