### PR TITLE
ci: publish docker image on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,6 @@ jobs:
           fetch-depth: 0
       - name: login to the registry
         uses: docker/login-action@v1
-        if: github.event_name != 'pull_request'
         with:
           registry: ${{env.registry}}
           username: ${{secrets.DOCKERHUB_USERNAME}}
@@ -31,9 +30,10 @@ jobs:
           images: ${{env.registry}}/${{env.repository}}
           tags: |
             type=semver,pattern={{version}}
+            type=ref,event=pr
       - name: docker build
         uses: docker/build-push-action@v2
         with:
-          push: ${{github.event_name != 'pull_request'}}
+          push: true
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,15 @@
 name: Build & Push
-# Build & Push builds the simapp docker image on every push to main and
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
 on:
-  push:
+  pull_request:
     branches:
       - main
+  push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
-
+env:
+  registry: docker.io
+  repository: line/lbm-simapp
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,27 +17,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=interchainio/simapp
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=latest
-            fi
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-          fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: login to the registry
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ${{env.registry}}
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
+      - name: extract metadata for docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{env.registry}}/${{env.repository}}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: docker build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{github.event_name != 'pull_request'}}
+          tags: ${{steps.meta.outputs.tags}}
+          labels: ${{steps.meta.outputs.labels}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 0
       - name: login to the registry
         uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           registry: ${{env.registry}}
           username: ${{secrets.DOCKERHUB_USERNAME}}
@@ -30,10 +31,9 @@ jobs:
           images: ${{env.registry}}/${{env.repository}}
           tags: |
             type=semver,pattern={{version}}
-            type=ref,event=pr
       - name: docker build
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{github.event_name != 'pull_request'}}
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,5 +49,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Build, CI
 
 * (ci) [\#457](https://github.com/line/lbm-sdk/pull/457) add swagger check
+* (ci) [\#469](https://github.com/line/lbm-sdk/pull/469) publish docker image on tag push
 
 ### Document Updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 FROM golang:alpine AS build-env
 
 # Install minimum necessary dependencies,
-ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+ENV PACKAGES curl make git libc-dev bash gcc g++ linux-headers eudev-dev python3
 RUN apk add --no-cache $PACKAGES
 
 # Set working directory for the build


### PR DESCRIPTION
It makes CI to publish the docker image on tag pushes.

## Description
It adds a workflow which publishes the docker image on tag push event.
The destination is docker.io/line/lbm-simapp for now.
The image tag would be the corresponding semver and `latest`.

closes: #455 

## Motivation and context
Refer to #455

## How has this been tested?
The PR will trigger the workflow. And I confirmed it works, I will revert the commit which triggers the workflow on PR.

## Checklist:
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes. [no need]
- [ ] I have updated the documentation accordingly. [no need]
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` [no need]
