### PR TITLE
fix: change the default value of the client output format in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 * (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path
+* (client) [\#476](https://github.com/line/lbm-sdk/pull/476) change the default value of the client output format in the config
 
 ### Breaking Changes
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -12,7 +12,7 @@ import (
 const (
 	chainID        = ""
 	keyringBackend = "os"
-	output         = "text"
+	output         = ""
 	node           = "tcp://localhost:26657"
 	broadcastMode  = "sync"
 )

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -12,7 +12,7 @@ import (
 const (
 	chainID        = ""
 	keyringBackend = "os"
-	output         = ""
+	output         = "text"
 	node           = "tcp://localhost:26657"
 	broadcastMode  = "sync"
 )

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -20,7 +20,7 @@ const defaultConfigTemplate = `# This is a TOML config file.
 chain-id = "{{ .ChainID }}"
 # The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
 keyring-backend = "{{ .KeyringBackend }}"
-# CLI output format (text|json)
+# CLI output format (text|json), it will override the default values of both query and tx.
 output = "{{ .Output }}"
 # <host>:<port> to Tendermint RPC interface for this chain
 node = "{{ .Node }}"

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -20,7 +20,7 @@ const defaultConfigTemplate = `# This is a TOML config file.
 chain-id = "{{ .ChainID }}"
 # The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
 keyring-backend = "{{ .KeyringBackend }}"
-# CLI output format (text|json)
+# CLI output format (text|json), it will override the default values of both query and tx
 output = "{{ .Output }}"
 # <host>:<port> to Tendermint RPC interface for this chain
 node = "{{ .Node }}"

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -20,7 +20,7 @@ const defaultConfigTemplate = `# This is a TOML config file.
 chain-id = "{{ .ChainID }}"
 # The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
 keyring-backend = "{{ .KeyringBackend }}"
-# CLI output format (text|json), it will override the default values of both query and tx.
+# CLI output format (text|json)
 output = "{{ .Output }}"
 # <host>:<port> to Tendermint RPC interface for this chain
 node = "{{ .Node }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It fixes the confusing behavior discussed in #473.
It's not a bug, but we concluded not to set the default value on the output format in the config file.

closes: #473

## Motivation and context

#473 

## How has this been tested?

Executed tx cli and confirmed the output is in json.
Also confirmed the output of query cli is in yaml.

Tested on Docker image, on Debian bookworm.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
