### PR TITLE
fix: restore norace tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 * (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path
 * (client) [\#476](https://github.com/line/lbm-sdk/pull/476) change the default value of the client output format in the config
+* (server/grpc) [\#516](https://github.com/line/lbm-sdk/pull/516) restore build norace flag
 
 ### Breaking Changes
 

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -1,3 +1,6 @@
+//go:build norace
+// +build norace
+
 package grpc_test
 
 import (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After bumping up to cosmos-sdk@0.45.1, errors frequently occur in the data race. in the process of work
I deleted the build tag for debugging, but it seems that an error like this occurred because it was not restored. 
I restored the build tag because the test code in server/grpc did not take the data race into account.

closes: #514 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
