### PR TITLE
fix: fix unmarshal bug of BaseAccountJSON.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (server/grpc) [\#516](https://github.com/line/lbm-sdk/pull/516) restore build norace flag
 * (genesis) [\#517](https://github.com/line/lbm-sdk/pull/517) fix genesis auth account format(cosmos-sdk style -> lbm-sdk style)
 * (x/foundation) [\#545](https://github.com/line/lbm-sdk/pull/545) fix genesis and support abstain
+* (x/auth) [\#563](https://github.com/line/lbm-sdk/pull/563) fix unmarshal bug of `BaseAccountJSON`
 
 ### Breaking Changes
 

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -438,7 +438,7 @@ type PubKeyJSON struct {
 type BaseAccountJSON struct {
 	Address       string     `json:"address"`
 	PubKey        PubKeyJSON `json:"pub_key"`
-	AccountNumber uint64     `json:"account_number"`
+	AccountNumber uint64     `json:"account_number,string"`
 	Sequence      string     `json:"sequence"`
 }
 

--- a/x/auth/types/account_test.go
+++ b/x/auth/types/account_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -235,6 +236,15 @@ func TestModuleAccountJSONPB(t *testing.T) {
 	// error on bad bytes
 	err = acc2.UnmarshalJSONPB(&jum, bz[:len(bz)/2])
 	require.Error(t, err)
+}
+
+func TestBaseAccountJSONPB(t *testing.T) {
+	baseAccountJson := "{\"address\":\"link1rrfywnytlm87ywes0hvxn4rhm4grrn9qquqljc\",\"pub_key\":{\"type\":0,\"key\":null},\"account_number\":\"10\",\"sequence\":\"50\"}"
+	ba := new(types.BaseAccount)
+	jum := jsonpb.Unmarshaler{}
+	err := jum.Unmarshal(strings.NewReader(baseAccountJson), ba)
+	require.NoError(t, err)
+	require.Equal(t, ba.AccountNumber, uint64(10))
 }
 
 func TestGenesisAccountsContains(t *testing.T) {

--- a/x/auth/types/account_test.go
+++ b/x/auth/types/account_test.go
@@ -239,7 +239,7 @@ func TestModuleAccountJSONPB(t *testing.T) {
 }
 
 func TestBaseAccountJSONPB(t *testing.T) {
-	baseAccountJson := "{\"address\":\"link1rrfywnytlm87ywes0hvxn4rhm4grrn9qquqljc\",\"pub_key\":{\"type\":0,\"key\":null},\"account_number\":\"10\",\"sequence\":\"50\"}"
+	baseAccountJson := `{"address":"link1rrfywnytlm87ywes0hvxn4rhm4grrn9qquqljc","pub_key":{"type":0,"key":null},"account_number":"10","sequence":"50"}`
 	ba := new(types.BaseAccount)
 	jum := jsonpb.Unmarshaler{}
 	err := jum.Unmarshal(strings.NewReader(baseAccountJson), ba)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed unmarshal error if  account_number of genesis auth's account is string type when load the genesis file

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
