### PR TITLE
fix: push docker image action.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,3 +37,4 @@ jobs:
           push: ${{github.event_name != 'pull_request'}}
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
+          platforms: linux/amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (ci) [\#457](https://github.com/line/lbm-sdk/pull/457), [\#471](https://github.com/line/lbm-sdk/pull/471) add swagger check
 * (ci) [\#469](https://github.com/line/lbm-sdk/pull/469) publish docker image on tag push
+* (ci) [\#580](https://github.com/line/lbm-sdk/pull/580) fix the problem that the registered docker image couldn't  run on M1.
 
 ### Document Updates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN make build-linux
 FROM alpine:edge
 
 # Install ca-certificates
-RUN apk add --update ca-certificates
+RUN apk add --update ca-certificates libstdc++
 WORKDIR /root
 
 # Copy over binaries from the build-env

--- a/go.mod
+++ b/go.mod
@@ -62,5 +62,6 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	github.com/herumi/bls-eth-go-binary => github.com/herumi/bls-eth-go-binary v0.0.0-20220509081320-2d8ab06de53c
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/jhump/protoreflect v1.10.3
 	github.com/line/iavl/v2 v2.0.0-init.1.0.20220215225951-cb11c91d8857
-	github.com/line/ostracon v1.0.6-0.20220614053335-f9d9fa2cc779
+	github.com/line/ostracon v1.0.6
 	github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486
 	github.com/line/wasmvm v0.16.3-0.9.0
 	github.com/magiconair/properties v1.8.6
@@ -62,6 +62,5 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/herumi/bls-eth-go-binary => github.com/herumi/bls-eth-go-binary v0.0.0-20220509081320-2d8ab06de53c
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -716,8 +716,8 @@ github.com/line/gorocksdb v0.0.0-20210406043732-d4bea34b6d55/go.mod h1:DHRJroSL7
 github.com/line/iavl/v2 v2.0.0-init.1.0.20220215225951-cb11c91d8857 h1:8kWqbLNeb37357e4U/7uLMVCRF3K9bxwTGb6JmRUKpI=
 github.com/line/iavl/v2 v2.0.0-init.1.0.20220215225951-cb11c91d8857/go.mod h1:uK2CYRdukSVRGhc5Q8zoDUnm/zAbfnZATbFXrfCrQKA=
 github.com/line/ostracon v0.34.9-0.20210429084710-ef4fe0a40c7d/go.mod h1:ttnbq+yQJMQ9a2MT5SEisOoa/+pOgh2KenTiK/rVdiw=
-github.com/line/ostracon v1.0.6-0.20220614053335-f9d9fa2cc779 h1:Nw+i074ivEcwtZd2MIY0HJh8UoRyh+iTlzgHSbssHPQ=
-github.com/line/ostracon v1.0.6-0.20220614053335-f9d9fa2cc779/go.mod h1:SGNYNMSs7/YNrsFg6FOIa5phmreBJxD7SaBmmijpfRc=
+github.com/line/ostracon v1.0.6 h1:NgFu4e9+ukalCizKLtHby6o7ofakSPkdV8yfzOe2urM=
+github.com/line/ostracon v1.0.6/go.mod h1:SGNYNMSs7/YNrsFg6FOIa5phmreBJxD7SaBmmijpfRc=
 github.com/line/tm-db/v2 v2.0.0-init.1.0.20210413083915-5bb60e117524/go.mod h1:wmkyPabXjtVZ1dvRofmurjaceghywtCSYGqFuFS+TbI=
 github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486 h1:uvXQdcWaUyNsgkXBz375FpQ285WEJaLXhQ5HtoNK/GU=
 github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486/go.mod h1:wmkyPabXjtVZ1dvRofmurjaceghywtCSYGqFuFS+TbI=

--- a/init_node.sh
+++ b/init_node.sh
@@ -21,7 +21,7 @@ redirect() {
   fi
 }
 
-BINARY=simd
+BINARY=./build/simd
 BASE_DIR=~/.simapp
 CHAIN_DIR_PREFIX="${BASE_DIR}/simapp"
 GENTXS_DIR="${BASE_DIR}/gentxs"

--- a/init_node.sh
+++ b/init_node.sh
@@ -21,7 +21,7 @@ redirect() {
   fi
 }
 
-BINARY=./build/simd
+BINARY=simd
 BASE_DIR=~/.simapp
 CHAIN_DIR_PREFIX="${BASE_DIR}/simapp"
 GENTXS_DIR="${BASE_DIR}/gentxs"


### PR DESCRIPTION
Signed-off-by: zemyblue <zemyblue@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The registered docker image of docker hub is not executed in Apple M1 Macbook. Because the docker image was not built with the `platforms` information, so I fix this problem in this PR. 

And `libstdc++` library is required for `linux/amd64` because `bls-eth-go-binary` of `ostracon`. So I add it in the `Dockerfile`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
