### PR TITLE
chore: revert gRPC block height header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#571](https://github.com/line/lbm-sdk/pull/571) add x/collection proto
 * (x/collection) [\#574](https://github.com/line/lbm-sdk/pull/574) implement x/collection
 * (amino) [\600](https://github.com/line/lbm-sdk/pull/600) change amino codec path from `lbm-sdk/` to `cosmos-sdk/`
+* (server/grpc) [\#607](https://github.com/line/lbm-sdk/pull/607) revert gRPC block height header.
 
 ### Improvements
 

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -190,7 +190,7 @@ func (s *IntegrationTestSuite) TestGRPCServer_BroadcastTx() {
 }
 
 // Test and enforce that we upfront reject any connections to baseapp containing
-// invalid initial x-lbm-block-height that aren't positive  and in the range [0, max(int64)]
+// invalid initial x-cosmos-block-height that aren't positive  and in the range [0, max(int64)]
 // See issue https://github.com/cosmos/cosmos-sdk/issues/7662.
 func (s *IntegrationTestSuite) TestGRPCServerInvalidHeaderHeights() {
 	t := s.T()

--- a/types/grpc/headers.go
+++ b/types/grpc/headers.go
@@ -2,5 +2,5 @@ package grpc
 
 const (
 	// GRPCBlockHeightHeader is the gRPC header for block height.
-	GRPCBlockHeightHeader = "x-lbm-block-height"
+	GRPCBlockHeightHeader = "x-cosmos-block-height"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert gRPC block height header.
`x-lbm-block-height` -> `x-cosmos-block-height`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think no need to keep the `x-lbm-block-height`.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
