### PR TITLE
fix: make x/collection Query/Balance not to panic on amount of zero in return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client) [\#565](https://github.com/line/lbm-sdk/pull/565) fix the data race problem in `TestQueryABCIHeight`
 * (x/token) [\#589](https://github.com/line/lbm-sdk/pull/589) fix naming collision in x/token enums
 * (x/token) [\#599](https://github.com/line/lbm-sdk/pull/599) fix the order of events
+* (x/collection) [\#645](https://github.com/line/lbm-sdk/pull/645) make x/collection Query/Balance not to panic on amount of zero in return
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -61,7 +61,12 @@ func (s queryServer) Balance(c context.Context, req *collection.QueryBalanceRequ
 	}
 
 	balance := s.keeper.GetBalance(ctx, req.ContractId, addr, req.TokenId)
-	coin := collection.NewCoin(req.TokenId, balance)
+
+	// amount could be zero.
+	coin := collection.Coin{
+		TokenId: req.TokenId,
+		Amount:  balance,
+	}
 
 	return &collection.QueryBalanceResponse{Balance: coin}, nil
 }

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -48,6 +48,18 @@ func (s queryServer) Balance(c context.Context, req *collection.QueryBalanceRequ
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
+	if _, err := s.keeper.GetContract(ctx, req.ContractId); err != nil {
+		return nil, err
+	}
+
+	// legacy compat.
+	classID := collection.SplitTokenID(req.TokenId)
+	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
+		return nil, sdkerrors.Wrapf(err, "corresponding token class not exists")
+	}
+
 	balance := s.keeper.GetBalance(ctx, req.ContractId, addr, req.TokenId)
 	coin := collection.NewCoin(req.TokenId, balance)
 
@@ -70,6 +82,12 @@ func (s queryServer) AllBalances(c context.Context, req *collection.QueryAllBala
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
+	if _, err := s.keeper.GetContract(ctx, req.ContractId); err != nil {
+		return nil, err
+	}
+
 	store := ctx.KVStore(s.keeper.storeKey)
 	balanceStore := prefix.NewStore(store, balanceKeyPrefixByAddress(req.ContractId, addr))
 	var balances []collection.Coin
@@ -108,9 +126,12 @@ func (s queryServer) FTSupply(c context.Context, req *collection.QueryFTSupplyRe
 	classID := collection.SplitTokenID(req.TokenId)
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	supply := s.keeper.GetSupply(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTSupplyResponse{Supply: supply}, nil
@@ -132,9 +153,12 @@ func (s queryServer) FTMinted(c context.Context, req *collection.QueryFTMintedRe
 	classID := collection.SplitTokenID(req.TokenId)
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	minted := s.keeper.GetMinted(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTMintedResponse{Minted: minted}, nil
@@ -156,9 +180,12 @@ func (s queryServer) FTBurnt(c context.Context, req *collection.QueryFTBurntRequ
 	classID := collection.SplitTokenID(req.TokenId)
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	burnt := s.keeper.GetBurnt(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTBurntResponse{Burnt: burnt}, nil
@@ -179,9 +206,12 @@ func (s queryServer) NFTSupply(c context.Context, req *collection.QueryNFTSupply
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	supply := s.keeper.GetSupply(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTSupplyResponse{Supply: supply}, nil
@@ -202,9 +232,12 @@ func (s queryServer) NFTMinted(c context.Context, req *collection.QueryNFTMinted
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	minted := s.keeper.GetMinted(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTMintedResponse{Minted: minted}, nil
@@ -225,9 +258,12 @@ func (s queryServer) NFTBurnt(c context.Context, req *collection.QueryNFTBurntRe
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	// legacy compat.
 	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
+
 	burnt := s.keeper.GetBurnt(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTBurntResponse{Burnt: burnt}, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch addresses the following issues on x/collection:
- Query/Balance panics where the returning balance is zero.
- The validation logic and the corresponding errors resemble that of the cosmos-sdk x/bank, not that of daphne.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
