### PR TITLE
fix: adjust gas cost for GetContractEnv of CosmWasmAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-* (x/wasm) [\#633](https://github.com/line/lbm-sdk/pull/633)Add benchmarks for cosmwasm APIs
+* (x/wasm) [\#659](https://github.com/line/lbm-sdk/pull/659) Adjust gas cost for GetContractEnv of CosmWasmAPI
+* (x/wasm) [\#633](https://github.com/line/lbm-sdk/pull/633) Add benchmarks for cosmwasm APIs
 * (x/wasm) [\#509](https://github.com/line/lbm-sdk/pull/590) Add integration tests for dynamic call
 
 ## [v0.43.0](https://github.com/line/lbm-sdk/releases/tag/v0.43.0)

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -43,7 +43,11 @@ func (a cosmwasmAPIImpl) GetContractEnv(contractAddrStr string) (wasmvm.Env, *wa
 
 	// prepare querier
 	querier := NewQueryHandler(*a.ctx, a.keeper.wasmVMQueryHandler, contractAddr, a.gasMultiplier)
-	gas := 20 * a.gasMultiplier
+
+	// this gas cost is temporal value defined by
+	// https://github.com/line/lbm-sdk/runs/8150140720?check_suite_focus=true#step:5:483
+	// Before release, it is adjusted by benchmark taken in environment similar to the nodes.
+	gas := 11 * a.gasMultiplier
 	wasmStore := types.NewWasmStore(prefixStore)
 	env := types.NewEnv(*a.ctx, contractAddr)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adjust gas cost of GetContractEnv following the benchmark.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes. (not needed)
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
