### PR TITLE
chore: change default `iavl-cache-size`

### DIFF
--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -66,7 +66,7 @@ inter-block-cache = {{ .BaseConfig.InterBlockCache }}
 # InterBlockCacheSize is the maximum bytes size of the inter-block cache.
 inter-block-cache-size = {{ .BaseConfig.InterBlockCacheSize }}
 
-# IAVLCacheSize is the maximum bytes size of iavl node cache
+# IAVLCacheSize is the maximum units size of iavl node cache (1 unit is 128 bytes)
 iavl-cache-size = {{ .BaseConfig.IAVLCacheSize }}
 
 # Bech32CacheSize is the maximum bytes size of bech32 cache (Default : 1GB)

--- a/server/start.go
+++ b/server/start.go
@@ -154,7 +154,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint64(FlagHaltTime, 0, "Minimum block time (in Unix seconds) at which to gracefully halt the chain and shutdown the node")
 	cmd.Flags().Bool(FlagInterBlockCache, true, "Enable inter-block caching")
 	cmd.Flags().Int(FlagInterBlockCacheSize, cache.DefaultCommitKVStoreCacheSize, "The maximum bytes size of the inter-block cache")
-	cmd.Flags().Int(FlagIAVLCacheSize, iavl.DefaultIAVLCacheSize, "The maximum bytes size of the iavl node cache")
+	cmd.Flags().Int(FlagIAVLCacheSize, iavl.DefaultIAVLCacheSize, "The maximum units size of the iavl node cache. (1 unit is 128 bytes")
 	cmd.Flags().String(flagCPUProfile, "", "Enable CPU profiling and write to the provided file")
 	cmd.Flags().Bool(FlagTrace, false, "Provide full stack traces for errors in ABCI Log")
 	cmd.Flags().String(FlagPruning, storetypes.PruningOptionDefault, "Pruning strategy (default|nothing|everything|custom)")

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -23,7 +23,9 @@ import (
 )
 
 const (
-	DefaultIAVLCacheSize = 1024 * 1024 * 100
+	// DefaultIAVLCacheSize is default Iavl cache units size. 1 unit is 128 byte
+	// default 128MB
+	DefaultIAVLCacheSize = 1048576
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: zemyblue <zemyblue@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change default `iavl-cache-size` of config.
Default real iavl cache size set 128MB.
So I set the `DefaultIAVLCacheSize = 1048576`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The iavl cach size of config is different with real cache size. 
The config setting size is the number of iavl cache unit. And 1 iavl cache unit is 128byte struct according to https://github.com/cosmos/cosmos-sdk/pull/10561#discussion_r756429413

So current default iavl cache size is so big.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
