### PR TITLE
fix the bug not setting `iavl-cache-size` value of `app.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/wasm) [\#640](https://github.com/line/lbm-sdk/pull/640) remove legacy codes of wasm
 * (amino) [\#635](https://github.com/line/lbm-sdk/pull/635) change some minor things that haven't been fixed in #549
 * (store) [\#666](https://github.com/line/lbm-sdk/pull/666) change default `iavl-cache-size` and description 
+* (simapp) [\#679](https://github.com/line/lbm-sdk/pull/679) fix the bug not setting `iavl-cache-size` value of `app.toml`
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -67,6 +67,8 @@ inter-block-cache = {{ .BaseConfig.InterBlockCache }}
 inter-block-cache-size = {{ .BaseConfig.InterBlockCacheSize }}
 
 # IAVLCacheSize is the maximum units size of iavl node cache (1 unit is 128 bytes)
+# This iavl cache size is just one store cache size, and the store exists for each modules.
+# So be careful that all iavl cache size are difference from this iavl cache size value.
 iavl-cache-size = {{ .BaseConfig.IAVLCacheSize }}
 
 # IndexEvents defines the set of events in the form {eventType}.{attributeKey},

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -282,6 +282,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetInterBlockCache(cache),
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	// DefaultIAVLCacheSize is default Iavl cache units size. 1 unit is 128 byte
-	// default 128MB
-	DefaultIAVLCacheSize = 1024 * 1024
+	// default 64MB
+	DefaultIAVLCacheSize = 1024 * 512
 )
 
 var (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the bug not setting `iavl-cache-size` value of `app.toml` of simapp

And change `DefaultIAVLCacheSize`  to 1024 * 512.
Because the iavl cache size is just one store's iavl cache size and each modules have itself's store. if the all module's store use iavl type, the default all iavl cache size is very big. So I change default size to a little small size. 

related: #666, #675 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
