### PR TITLE
refactor: remove `MinThreshold` and `MinPercentage` from x/foundation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#639](https://github.com/line/lbm-sdk/pull/639) rename x/collection events
 * (x/wasm) [\#661](https://github.com/line/lbm-sdk/pull/661) x/wasm refactoring - detaching the custom wasm proto part of lbm-sdk. (apply changes of [\#625](https://github.com/line/lbm-sdk/pull/625) and [\#655](https://github.com/line/lbm-sdk/pull/655))
 * (refactor) [\#685](https://github.com/line/lbm-sdk/pull/685) remove x/foundation UpdateValidatorAuthsProposal
+* (refactor) [\#686](https://github.com/line/lbm-sdk/pull/686) remove `Minthreshold` and `MinPercentage` from x/foundation config
 
 ### Bug Fixes
 * (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#639](https://github.com/line/lbm-sdk/pull/639) rename x/collection events
 * (x/wasm) [\#661](https://github.com/line/lbm-sdk/pull/661) x/wasm refactoring - detaching the custom wasm proto part of lbm-sdk. (apply changes of [\#625](https://github.com/line/lbm-sdk/pull/625) and [\#655](https://github.com/line/lbm-sdk/pull/655))
 * (refactor) [\#685](https://github.com/line/lbm-sdk/pull/685) remove x/foundation UpdateValidatorAuthsProposal
-* (refactor) [\#686](https://github.com/line/lbm-sdk/pull/686) remove `Minthreshold` and `MinPercentage` from x/foundation config
+* (x/foundation) [\#686](https://github.com/line/lbm-sdk/pull/686) remove `Minthreshold` and `MinPercentage` from x/foundation config
 
 ### Bug Fixes
 * (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path

--- a/x/foundation/config.go
+++ b/x/foundation/config.go
@@ -2,8 +2,6 @@ package foundation
 
 import (
 	"time"
-
-	sdk "github.com/line/lbm-sdk/types"
 )
 
 // Config is a config struct used for intialising the group module to avoid using globals.
@@ -12,15 +10,11 @@ type Config struct {
 	MaxExecutionPeriod time.Duration
 	// MaxMetadataLen defines the max length of the metadata bytes field for various entities within the foundation module. Defaults to 255 if not explicitly set.
 	MaxMetadataLen uint64
-	MinThreshold   sdk.Dec
-	MinPercentage  sdk.Dec
 }
 
 func DefaultConfig() Config {
 	return Config{
 		MaxExecutionPeriod: 2 * 7 * 24 * time.Hour, // two weeks
 		MaxMetadataLen:     255,
-		MinThreshold:       sdk.NewDec(3),
-		MinPercentage:      sdk.MustNewDecFromStr("0.8"),
 	}
 }

--- a/x/foundation/foundation.go
+++ b/x/foundation/foundation.go
@@ -12,9 +12,9 @@ import (
 	sdkerrors "github.com/line/lbm-sdk/types/errors"
 )
 
-func DefaultDecisionPolicy(config Config) DecisionPolicy {
+func DefaultDecisionPolicy() DecisionPolicy {
 	return &ThresholdDecisionPolicy{
-		Threshold: config.MinThreshold,
+		Threshold: sdk.OneDec(),
 		Windows: &DecisionPolicyWindows{
 			VotingPeriod: 24 * time.Hour,
 		},
@@ -275,7 +275,7 @@ func (p ThresholdDecisionPolicy) GetVotingPeriod() time.Duration {
 }
 
 func (p ThresholdDecisionPolicy) ValidateBasic() error {
-	if !p.Threshold.IsPositive() {
+	if p.Threshold.IsNil() || !p.Threshold.IsPositive() {
 		return sdkerrors.ErrInvalidRequest.Wrap("threshold must be a positive number")
 	}
 
@@ -286,10 +286,6 @@ func (p ThresholdDecisionPolicy) ValidateBasic() error {
 }
 
 func (p ThresholdDecisionPolicy) Validate(config Config) error {
-	if p.Threshold.LT(config.MinThreshold) {
-		return sdkerrors.ErrInvalidRequest.Wrap("threshold must be greater than or equal to min_threshold")
-	}
-
 	if err := validateDecisionPolicyWindows(*p.Windows, config); err != nil {
 		return err
 	}
@@ -343,10 +339,6 @@ func (p PercentageDecisionPolicy) ValidateBasic() error {
 }
 
 func (p PercentageDecisionPolicy) Validate(config Config) error {
-	if p.Percentage.LT(config.MinPercentage) {
-		return sdkerrors.ErrInvalidRequest.Wrap("percentage must be greater than or equal to min_percentage")
-	}
-
 	if err := validateDecisionPolicyWindows(*p.Windows, config); err != nil {
 		return err
 	}

--- a/x/foundation/foundation_test.go
+++ b/x/foundation/foundation_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDecisionPolicy(t *testing.T) {
 	config := foundation.DefaultConfig()
-	policy := foundation.DefaultDecisionPolicy(config)
+	policy := foundation.DefaultDecisionPolicy()
 
 	require.NoError(t, policy.ValidateBasic())
 	require.NoError(t, policy.Validate(config))
@@ -53,24 +53,22 @@ func TestThresholdDecisionPolicy(t *testing.T) {
 		valid              bool
 	}{
 		"valid policy": {
-			threshold:          config.MinThreshold,
+			threshold:          sdk.OneDec(),
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour - time.Nanosecond,
 			validBasic:         true,
 			valid:              true,
 		},
-		"invalid policy (basic)": {
-			threshold:          config.MinThreshold,
-			minExecutionPeriod: config.MaxExecutionPeriod - time.Nanosecond,
-		},
-		"invalid policy": {
-			threshold:          config.MinThreshold.Sub(sdk.SmallestDec()),
+		"invalid threshold": {
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour - time.Nanosecond,
-			validBasic:         true,
 		},
-		"invalid policy (windows)": {
-			threshold:          config.MinThreshold,
+		"invalid voting period": {
+			threshold:          sdk.OneDec(),
+			minExecutionPeriod: config.MaxExecutionPeriod - time.Nanosecond,
+		},
+		"invalid min execution period": {
+			threshold:          sdk.OneDec(),
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour,
 			validBasic:         true,
@@ -133,8 +131,8 @@ func TestThresholdDecisionPolicyAllow(t *testing.T) {
 		},
 		"allow (member size < threshold)": {
 			sinceSubmission: policy.Windows.MinExecutionPeriod,
-			totalWeight:     config.MinThreshold,
-			tally:           foundation.NewTallyResult(config.MinThreshold, sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+			totalWeight:     sdk.OneDec(),
+			tally:           foundation.NewTallyResult(sdk.OneDec(), sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 			valid:           true,
 			final:           true,
 			allow:           true,
@@ -185,24 +183,22 @@ func TestPercentageDecisionPolicy(t *testing.T) {
 		valid              bool
 	}{
 		"valid policy": {
-			percentage:         config.MinPercentage,
+			percentage:         sdk.OneDec(),
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour - time.Nanosecond,
 			validBasic:         true,
 			valid:              true,
 		},
-		"invalid policy (basic)": {
-			percentage:         config.MinPercentage,
-			minExecutionPeriod: config.MaxExecutionPeriod - time.Nanosecond,
-		},
-		"invalid policy": {
-			percentage:         config.MinPercentage.Sub(sdk.SmallestDec()),
+		"invalid percentage": {
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour - time.Nanosecond,
-			validBasic:         true,
 		},
-		"invalid policy (windows)": {
-			percentage:         config.MinPercentage,
+		"invalid voting period": {
+			percentage:         sdk.OneDec(),
+			minExecutionPeriod: config.MaxExecutionPeriod - time.Nanosecond,
+		},
+		"invalid min execution period": {
+			percentage:         sdk.OneDec(),
 			votingPeriod:       time.Hour,
 			minExecutionPeriod: config.MaxExecutionPeriod + time.Hour,
 			validBasic:         true,

--- a/x/foundation/keeper/genesis.go
+++ b/x/foundation/keeper/genesis.go
@@ -85,7 +85,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, sk foundation.StakingKeeper, data *
 	if info.GetDecisionPolicy() == nil ||
 		info.GetDecisionPolicy().ValidateBasic() != nil ||
 		info.GetDecisionPolicy().Validate(k.config) != nil {
-		policy := foundation.DefaultDecisionPolicy(k.config)
+		policy := foundation.DefaultDecisionPolicy()
 		if err := info.SetDecisionPolicy(policy); err != nil {
 			return err
 		}

--- a/x/foundation/keeper/genesis_test.go
+++ b/x/foundation/keeper/genesis_test.go
@@ -22,7 +22,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.ZeroDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 			},
 		},
 		"enabled with no create validator grantees": {
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.ZeroDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 			},
 		},
 		"members": {
@@ -61,7 +61,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.OneDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 				Members: []foundation.Member{
 					{
 						Address:       s.members[0].String(),
@@ -98,7 +98,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.ZeroDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 				Proposals: []foundation.Proposal{
 					*foundation.Proposal{
 						Id:                1,
@@ -140,7 +140,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.ZeroDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 				Authorizations: []foundation.GrantAuthorization{
 					*foundation.GrantAuthorization{
 						Grantee: s.stranger.String(),
@@ -165,7 +165,7 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 					Operator:    s.keeper.GetAdmin(s.ctx).String(),
 					Version:     1,
 					TotalWeight: sdk.OneDec(),
-				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy(foundation.DefaultConfig())),
+				}.WithDecisionPolicy(foundation.DefaultDecisionPolicy()),
 				Authorizations: []foundation.GrantAuthorization{
 					*foundation.GrantAuthorization{
 						Grantee: s.stranger.String(),

--- a/x/foundation/keeper/keeper_test.go
+++ b/x/foundation/keeper/keeper_test.go
@@ -73,7 +73,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	}
 
 	s.operator = s.keeper.GetOperator(s.ctx)
-	s.members = make([]sdk.AccAddress, foundation.DefaultConfig().MinThreshold.TruncateInt64())
+	s.members = make([]sdk.AccAddress, 10)
 	for i := range s.members {
 		s.members[i] = createAddress()
 	}

--- a/x/foundation/keeper/member_test.go
+++ b/x/foundation/keeper/member_test.go
@@ -13,52 +13,18 @@ func (s *KeeperTestSuite) TestUpdateDecisionPolicy() {
 		policy foundation.DecisionPolicy
 		valid  bool
 	}{
-		"threshold policy (valid)": {
-			policy: &foundation.ThresholdDecisionPolicy{
-				Threshold: config.MinThreshold,
-				Windows: &foundation.DecisionPolicyWindows{
-					VotingPeriod: time.Hour,
-				},
-			},
-			valid: true,
-		},
-		"threshold policy (low threshold)": {
+		"valid policy": {
 			policy: &foundation.ThresholdDecisionPolicy{
 				Threshold: sdk.OneDec(),
 				Windows: &foundation.DecisionPolicyWindows{
 					VotingPeriod: time.Hour,
 				},
 			},
-		},
-		"threshold policy (invalid min execution period)": {
-			policy: &foundation.ThresholdDecisionPolicy{
-				Threshold: config.MinThreshold,
-				Windows: &foundation.DecisionPolicyWindows{
-					VotingPeriod:       time.Hour,
-					MinExecutionPeriod: time.Hour + config.MaxExecutionPeriod,
-				},
-			},
-		},
-		"percentage policy (valid)": {
-			policy: &foundation.PercentageDecisionPolicy{
-				Percentage: config.MinPercentage,
-				Windows: &foundation.DecisionPolicyWindows{
-					VotingPeriod: time.Hour,
-				},
-			},
 			valid: true,
 		},
-		"percentage policy (low percentage)": {
-			policy: &foundation.PercentageDecisionPolicy{
-				Percentage: sdk.MustNewDecFromStr("0.1"),
-				Windows: &foundation.DecisionPolicyWindows{
-					VotingPeriod: time.Hour,
-				},
-			},
-		},
-		"percentage policy (invalid min execution period)": {
-			policy: &foundation.PercentageDecisionPolicy{
-				Percentage: config.MinPercentage,
+		"invalid policy (invalid min execution period)": {
+			policy: &foundation.ThresholdDecisionPolicy{
+				Threshold: sdk.OneDec(),
 				Windows: &foundation.DecisionPolicyWindows{
 					VotingPeriod:       time.Hour,
 					MinExecutionPeriod: time.Hour + config.MaxExecutionPeriod,

--- a/x/foundation/keeper/msg_server_test.go
+++ b/x/foundation/keeper/msg_server_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	sdk "github.com/line/lbm-sdk/types"
 	"github.com/line/lbm-sdk/x/foundation"
 	"github.com/line/lbm-sdk/x/stakingplus"
@@ -98,7 +100,7 @@ func (s *KeeperTestSuite) TestMsgUpdateDecisionPolicy() {
 		"valid request": {
 			operator: s.operator,
 			policy: &foundation.ThresholdDecisionPolicy{
-				Threshold: foundation.DefaultConfig().MinThreshold,
+				Threshold: sdk.OneDec(),
 				Windows:   &foundation.DecisionPolicyWindows{},
 			},
 			valid: true,
@@ -106,15 +108,18 @@ func (s *KeeperTestSuite) TestMsgUpdateDecisionPolicy() {
 		"not authorized": {
 			operator: s.stranger,
 			policy: &foundation.ThresholdDecisionPolicy{
-				Threshold: foundation.DefaultConfig().MinThreshold,
+				Threshold: sdk.OneDec(),
 				Windows:   &foundation.DecisionPolicyWindows{},
 			},
 		},
-		"low threshold": {
+		"invalid policy": {
 			operator: s.operator,
 			policy: &foundation.ThresholdDecisionPolicy{
 				Threshold: sdk.OneDec(),
-				Windows:   &foundation.DecisionPolicyWindows{},
+				Windows: &foundation.DecisionPolicyWindows{
+					VotingPeriod:       time.Hour,
+					MinExecutionPeriod: foundation.DefaultConfig().MaxExecutionPeriod + time.Hour,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the minimum boundary of the policies:
- `MinThreshold`
- `MinPercentage`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After this patch is applied, we could out-source the proposal relevant logic to `x/group` later.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
