### PR TITLE
fix: fix bugs on aborting x/foundation proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (amino) [\#635](https://github.com/line/lbm-sdk/pull/635) change some minor things that haven't been fixed in #549
 * (store) [\#666](https://github.com/line/lbm-sdk/pull/666) change default `iavl-cache-size` and description 
 * (simapp) [\#679](https://github.com/line/lbm-sdk/pull/679) fix the bug not setting `iavl-cache-size` value of `app.toml`
+* (x/foundation) [\#687](https://github.com/line/lbm-sdk/pull/687) fix bugs on aborting x/foundation proposals
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/x/foundation/keeper/exec_test.go
+++ b/x/foundation/keeper/exec_test.go
@@ -17,8 +17,8 @@ func (s *KeeperTestSuite) TestExec() {
 			proposalID: s.invalidProposal,
 			valid:      true,
 		},
-		"aborted proposal": {
-			proposalID: s.abortedProposal,
+		"withdrawn proposal": {
+			proposalID: s.withdrawnProposal,
 		},
 	}
 

--- a/x/foundation/keeper/keeper_test.go
+++ b/x/foundation/keeper/keeper_test.go
@@ -51,10 +51,10 @@ type KeeperTestSuite struct {
 	members  []sdk.AccAddress
 	stranger sdk.AccAddress
 
-	activeProposal  uint64
-	votedProposal   uint64
-	abortedProposal uint64
-	invalidProposal uint64
+	activeProposal    uint64
+	votedProposal     uint64
+	withdrawnProposal uint64
+	invalidProposal   uint64
 
 	balance sdk.Int
 }
@@ -147,8 +147,8 @@ func (s *KeeperTestSuite) SetupTest() {
 		s.Require().NoError(err)
 	}
 
-	// create an aborted proposal
-	s.abortedProposal, err = s.keeper.SubmitProposal(s.ctx, []string{s.members[0].String()}, "", []sdk.Msg{
+	// create an withdrawn proposal
+	s.withdrawnProposal, err = s.keeper.SubmitProposal(s.ctx, []string{s.members[0].String()}, "", []sdk.Msg{
 		&foundation.MsgWithdrawFromTreasury{
 			Operator: s.operator.String(),
 			To:       s.stranger.String(),
@@ -156,7 +156,7 @@ func (s *KeeperTestSuite) SetupTest() {
 		},
 	})
 	s.Require().NoError(err)
-	err = s.keeper.WithdrawProposal(s.ctx, s.abortedProposal)
+	err = s.keeper.WithdrawProposal(s.ctx, s.withdrawnProposal)
 	s.Require().NoError(err)
 
 	// create an invalid proposal which contains invalid message

--- a/x/foundation/keeper/msg_server_test.go
+++ b/x/foundation/keeper/msg_server_test.go
@@ -289,7 +289,7 @@ func (s *KeeperTestSuite) TestMsgWithdrawProposal() {
 			address: s.stranger,
 		},
 		"inactive proposal": {
-			proposalID: s.abortedProposal,
+			proposalID: s.withdrawnProposal,
 			address:    s.members[0],
 		},
 	}

--- a/x/foundation/keeper/proposal.go
+++ b/x/foundation/keeper/proposal.go
@@ -130,7 +130,7 @@ func (k Keeper) abortOldProposals(ctx sdk.Context) {
 	latestVersion := k.GetFoundationInfo(ctx).Version
 
 	k.iterateProposals(ctx, func(proposal foundation.Proposal) (stop bool) {
-		if proposal.FoundationVersion != latestVersion-1 {
+		if proposal.FoundationVersion == latestVersion {
 			return true
 		}
 

--- a/x/foundation/keeper/proposal_test.go
+++ b/x/foundation/keeper/proposal_test.go
@@ -82,7 +82,7 @@ func (s *KeeperTestSuite) TestWithdrawProposal() {
 			valid: true,
 		},
 		"not active": {
-			id: s.abortedProposal,
+			id: s.withdrawnProposal,
 		},
 	}
 

--- a/x/foundation/keeper/vote_test.go
+++ b/x/foundation/keeper/vote_test.go
@@ -34,7 +34,7 @@ func (s *KeeperTestSuite) TestVote() {
 			option:     foundation.VOTE_OPTION_YES,
 		},
 		"inactive proposal": {
-			proposalID: s.abortedProposal,
+			proposalID: s.withdrawnProposal,
 			voter:      s.members[0],
 			option:     foundation.VOTE_OPTION_YES,
 		},

--- a/x/foundation/msgs_test.go
+++ b/x/foundation/msgs_test.go
@@ -45,7 +45,7 @@ func TestMsgFundTreasury(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -96,7 +96,7 @@ func TestMsgWithdrawFromTreasury(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -161,7 +161,7 @@ func TestMsgUpdateMembers(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -250,7 +250,7 @@ func TestMsgUpdateDecisionPolicy(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -336,7 +336,7 @@ func TestMsgSubmitProposal(t *testing.T) {
 		err = msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -377,7 +377,7 @@ func TestMsgWithdrawProposal(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -440,7 +440,7 @@ func TestMsgVote(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -481,7 +481,7 @@ func TestMsgExec(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -514,7 +514,7 @@ func TestMsgLeaveFoundation(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -566,7 +566,7 @@ func TestMsgGrant(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 
@@ -616,7 +616,7 @@ func TestMsgRevoke(t *testing.T) {
 		err := msg.ValidateBasic()
 		if !tc.valid {
 			require.Error(t, err, name)
-			return
+			continue
 		}
 		require.NoError(t, err, name)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch will fix the stopping logic in the iteration of the `abortOldProposals()`, and add the corresponding unit test.
It also fixes the misleading variable names of proposal in the test.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It didn't update the state of the latest proposals (to aborted), if there are proposals of multiple foundation versions.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
