### PR TITLE
chore: replace deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (store) [\#666](https://github.com/line/lbm-sdk/pull/666) change default `iavl-cache-size` and description 
 * (simapp) [\#679](https://github.com/line/lbm-sdk/pull/679) fix the bug not setting `iavl-cache-size` value of `app.toml`
 * (x/foundation) [\#687](https://github.com/line/lbm-sdk/pull/687) fix bugs on aborting x/foundation proposals
+* (global) [\#694](https://github.com/line/lbm-sdk/pull/694) replace deprecated functions since go 1.16 or 1.17
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strings"
@@ -134,7 +133,7 @@ func setupBaseAppWithSnapshots(t *testing.T, blocks uint, blockTxs int, options 
 
 	snapshotInterval := uint64(2)
 	snapshotTimeout := 1 * time.Minute
-	snapshotDir, err := ioutil.TempDir("", "baseapp")
+	snapshotDir, err := os.MkdirTemp("", "baseapp")
 	require.NoError(t, err)
 	snapshotStore, err := snapshots.NewStore(dbm.NewMemDB(), snapshotDir)
 	require.NoError(t, err)

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -2,8 +2,8 @@ package config_test
 
 import (
 	"bytes"
-	//"fmt"
-	"io/ioutil"
+	"io"
+
 	"os"
 	"testing"
 
@@ -57,7 +57,7 @@ func TestConfigCmd(t *testing.T) {
 	cmd.SetOut(b)
 	cmd.SetArgs([]string{"node"})
 	cmd.Execute()
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Equal(t, string(out), testNode1+"\n")
 }

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -43,7 +42,7 @@ func writeConfigToFile(configFilePath string, config *ClientConfig) error {
 		return err
 	}
 
-	return ioutil.WriteFile(configFilePath, buffer.Bytes(), 0600)
+	return os.WriteFile(configFilePath, buffer.Bytes(), 0600)
 }
 
 // ensureConfigPath creates a directory configPath if it does not exist

--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/line/ostracon/libs/cli"
@@ -179,7 +179,7 @@ func Test_runAddCmdLedgerDryRun(t *testing.T) {
 				_, err = kb.Key("testkey")
 				require.NoError(t, err)
 
-				out, err := ioutil.ReadAll(b)
+				out, err := io.ReadAll(b)
 				require.NoError(t, err)
 				require.Contains(t, string(out), "name: testkey")
 			} else {

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	bip39 "github.com/cosmos/go-bip39"
@@ -262,7 +262,7 @@ func Test_runAddCmdDryRun(t *testing.T) {
 				_, err = kb.Key("testkey")
 				require.NoError(t, err)
 
-				out, err := ioutil.ReadAll(b)
+				out, err := io.ReadAll(b)
 				require.NoError(t, err)
 				require.Contains(t, string(out), "name: testkey")
 			} else {

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -2,7 +2,7 @@ package keys
 
 import (
 	"bufio"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -24,7 +24,7 @@ func ImportKeyCommand() *cobra.Command {
 			}
 			buf := bufio.NewReader(clientCtx.Input)
 
-			bz, err := ioutil.ReadFile(args[1])
+			bz, err := os.ReadFile(args[1])
 			if err != nil {
 				return err
 			}

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -3,7 +3,6 @@ package keys
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,7 +94,7 @@ Ax9IQsSq+jOWkPRDJQ69a5/uUm4XliPim/CbYDVoXO6D3fts5IEXcUTmIa60ynC/
 
 			keyfile := filepath.Join(kbHome, "key.asc")
 
-			require.NoError(t, ioutil.WriteFile(keyfile, []byte(armoredKey), 0644))
+			require.NoError(t, os.WriteFile(keyfile, []byte(armoredKey), 0644))
 
 			defer func() {
 				_ = os.RemoveAll(kbHome)

--- a/codec/unknownproto/unknown_fields.go
+++ b/codec/unknownproto/unknown_fields.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"sync"
@@ -358,7 +358,7 @@ func extractFileDescMessageDesc(desc descriptorIface) (*descriptor.FileDescripto
 	if err != nil {
 		return nil, nil, err
 	}
-	protoBlob, err := ioutil.ReadAll(gzr)
+	protoBlob, err := io.ReadAll(gzr)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cosmovisor/upgrade.go
+++ b/cosmovisor/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -106,7 +105,7 @@ func GetDownloadURL(info *UpgradeInfo) (string, error) {
 	doc := strings.TrimSpace(info.Info)
 	// if this is a url, then we download that and try to get a new doc with the real info
 	if _, err := url.Parse(doc); err == nil {
-		tmpDir, err := ioutil.TempDir("", "upgrade-manager-reference")
+		tmpDir, err := os.MkdirTemp("", "upgrade-manager-reference")
 		if err != nil {
 			return "", fmt.Errorf("create tempdir for reference file: %w", err)
 		}
@@ -117,7 +116,7 @@ func GetDownloadURL(info *UpgradeInfo) (string, error) {
 			return "", fmt.Errorf("downloading reference link %s: %w", doc, err)
 		}
 
-		refBytes, err := ioutil.ReadFile(refPath)
+		refBytes, err := os.ReadFile(refPath)
 		if err != nil {
 			return "", fmt.Errorf("reading downloaded reference: %w", err)
 		}

--- a/crypto/hd/fundraiser_test.go
+++ b/crypto/hd/fundraiser_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func initFundraiserTestVectors(t *testing.T) []addrData {
 	// var hdPath string = "m/44'/118'/0'/0/0"
 	var hdToAddrTable []addrData
 
-	b, err := ioutil.ReadFile("testdata/test.json")
+	b, err := os.ReadFile("testdata/test.json")
 	if err != nil {
 		t.Fatalf("could not read fundraiser test vector file (testdata/test.json): %s", err)
 	}

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -673,7 +672,7 @@ func newRealPrompt(dir string, buf io.Reader) func(string) (string, error) {
 
 		switch {
 		case err == nil:
-			keyhash, err = ioutil.ReadFile(keyhashFilePath)
+			keyhash, err = os.ReadFile(keyhashFilePath)
 			if err != nil {
 				return "", fmt.Errorf("failed to read %s: %v", keyhashFilePath, err)
 			}
@@ -737,7 +736,7 @@ func newRealPrompt(dir string, buf io.Reader) func(string) (string, error) {
 				continue
 			}
 
-			if err := ioutil.WriteFile(dir+"/keyhash", passwordHash, 0555); err != nil {
+			if err := os.WriteFile(dir+"/keyhash", passwordHash, 0555); err != nil {
 				return "", err
 			}
 

--- a/server/export.go
+++ b/server/export.go
@@ -4,7 +4,6 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	ostjson "github.com/line/ostracon/libs/json"
@@ -49,7 +48,7 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 					return err
 				}
 
-				genesis, err := ioutil.ReadFile(config.GenesisFile())
+				genesis, err := os.ReadFile(config.GenesisFile())
 				if err != nil {
 					return err
 				}

--- a/server/grpc/gogoreflection/serverreflection.go
+++ b/server/grpc/gogoreflection/serverreflection.go
@@ -41,7 +41,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"reflect"
 	"sort"
@@ -219,7 +218,7 @@ func decompress(b []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bad gzipped descriptor: %v", err)
 	}
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("bad gzipped descriptor: %v", err)
 	}

--- a/server/grpc/grpc_web_test.go
+++ b/server/grpc/grpc_web_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -198,7 +197,7 @@ func (s *GRPCWebTestSuite) makeGrpcRequest(
 		return nil, Trailer{}, nil, err
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, Trailer{}, nil, err
 	}

--- a/server/mock/helpers.go
+++ b/server/mock/helpers.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	abci "github.com/line/ostracon/abci/types"
@@ -14,7 +13,7 @@ import (
 func SetupApp() (abci.Application, func(), error) {
 	logger := log.NewOCLogger(log.NewSyncWriter(os.Stdout)).
 		With("module", "mock")
-	rootDir, err := ioutil.TempDir("", "mock-sdk")
+	rootDir, err := os.MkdirTemp("", "mock-sdk")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/simapp/state.go
+++ b/simapp/state.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	ostjson "github.com/line/ostracon/libs/json"
@@ -55,7 +55,7 @@ func AppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager) simty
 
 		case config.ParamsFile != "":
 			appParams := make(simtypes.AppParams)
-			bz, err := ioutil.ReadFile(config.ParamsFile)
+			bz, err := os.ReadFile(config.ParamsFile)
 			if err != nil {
 				panic(err)
 			}
@@ -184,7 +184,7 @@ func AppStateRandomizedFn(
 // AppStateFromGenesisFileFn util function to generate the genesis AppState
 // from a genesis.json file.
 func AppStateFromGenesisFileFn(r io.Reader, cdc codec.JSONCodec, genesisFile string) (octypes.GenesisDoc, []simtypes.Account) {
-	bytes, err := ioutil.ReadFile(genesisFile)
+	bytes, err := os.ReadFile(genesisFile)
 	if err != nil {
 		panic(err)
 	}

--- a/simapp/test_helpers.go
+++ b/simapp/test_helpers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -56,7 +56,7 @@ var DefaultConsensusParams = &abci.ConsensusParams{
 }
 
 func setup(withGenesis bool, invCheckPeriod uint, opts ...wasm.Option) (*SimApp, GenesisState) {
-	randDir, _ := ioutil.TempDir(DefaultNodeHome, "")
+	randDir, _ := os.MkdirTemp(DefaultNodeHome, "")
 	snapshotDir := filepath.Join(randDir, "data", "snapshots")
 	snapshotDB := dbm.NewMemDB()
 

--- a/simapp/utils.go
+++ b/simapp/utils.go
@@ -3,7 +3,7 @@ package simapp
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/ostracon/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -34,7 +34,7 @@ func SetupSimulation(dirPrefix, dbName string) (simtypes.Config, dbm.DB, string,
 		logger = log.NewNopLogger()
 	}
 
-	dir, err := ioutil.TempDir("", dirPrefix)
+	dir, err := os.MkdirTemp("", dirPrefix)
 	if err != nil {
 		return simtypes.Config{}, nil, "", nil, false, err
 	}
@@ -56,7 +56,7 @@ func SimulationOperations(app App, cdc codec.JSONCodec, config simtypes.Config) 
 	}
 
 	if config.ParamsFile != "" {
-		bz, err := ioutil.ReadFile(config.ParamsFile)
+		bz, err := os.ReadFile(config.ParamsFile)
 		if err != nil {
 			panic(err)
 		}
@@ -84,7 +84,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportStatePath, []byte(exported.AppState), 0600); err != nil {
+		if err := os.WriteFile(config.ExportStatePath, []byte(exported.AppState), 0600); err != nil {
 			return err
 		}
 	}
@@ -96,7 +96,7 @@ func CheckExportSimulation(
 			return err
 		}
 
-		if err := ioutil.WriteFile(config.ExportParamsPath, paramsBz, 0600); err != nil {
+		if err := os.WriteFile(config.ExportParamsPath, paramsBz, 0600); err != nil {
 			return err
 		}
 	}

--- a/snapshots/chunk_test.go
+++ b/snapshots/chunk_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,10 +65,10 @@ func TestChunkWriter(t *testing.T) {
 		require.NoError(t, err)
 		chunkWriter.CloseWithError(theErr)
 	}()
-	chunk, err := ioutil.ReadAll(<-ch)
+	chunk, err := io.ReadAll(<-ch)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{1, 2}, chunk)
-	_, err = ioutil.ReadAll(<-ch)
+	_, err = io.ReadAll(<-ch)
 	require.Error(t, err)
 	assert.Equal(t, theErr, err)
 	assert.Empty(t, ch)
@@ -144,7 +143,7 @@ func TestChunkReader(t *testing.T) {
 	// Closing the reader should close the writer
 	pr, pw = io.Pipe()
 	pch = make(chan io.ReadCloser, 2)
-	pch <- ioutil.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
+	pch <- io.NopCloser(bytes.NewBuffer([]byte{1, 2, 3}))
 	pch <- pr
 	close(pch)
 

--- a/snapshots/helpers_test.go
+++ b/snapshots/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ func hash(chunks [][]byte) []byte {
 func makeChunks(chunks [][]byte) <-chan io.ReadCloser {
 	ch := make(chan io.ReadCloser, len(chunks))
 	for _, chunk := range chunks {
-		ch <- ioutil.NopCloser(bytes.NewReader(chunk))
+		ch <- io.NopCloser(bytes.NewReader(chunk))
 	}
 	close(ch)
 	return ch
@@ -53,7 +52,7 @@ func makeChunks(chunks [][]byte) <-chan io.ReadCloser {
 func readChunks(chunks <-chan io.ReadCloser) [][]byte {
 	bodies := [][]byte{}
 	for chunk := range chunks {
-		body, err := ioutil.ReadAll(chunk)
+		body, err := io.ReadAll(chunk)
 		if err != nil {
 			panic(err)
 		}
@@ -146,10 +145,10 @@ func (m *mockSnapshotter) SupportedFormats() []uint32 {
 // setupBusyManager creates a manager with an empty store that is busy creating a snapshot at height 1.
 // The snapshot will complete when the returned closer is called.
 func setupBusyManager(t *testing.T) *snapshots.Manager {
-	// ioutil.TempDir() is used instead of testing.T.TempDir()
+	// os.MkdirTemp() is used instead of testing.T.TempDir()
 	// see https://github.com/cosmos/cosmos-sdk/pull/8475 for
 	// this change's rationale.
-	tempdir, err := ioutil.TempDir("", "")
+	tempdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(tempdir) })
 

--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"sort"
 	"sync"
@@ -220,7 +219,7 @@ func (m *Manager) LoadChunk(height uint64, format uint32, chunk uint32) ([]byte,
 	}
 	defer reader.Close()
 
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 // Prune prunes snapshots, if no other operations are in progress.
@@ -353,7 +352,7 @@ func (m *Manager) RestoreChunk(chunk []byte) (bool, error) {
 	}
 
 	// Pass the chunk to the restore, and wait for completion if it was the final one.
-	m.chRestore <- ioutil.NopCloser(bytes.NewReader(chunk))
+	m.chRestore <- io.NopCloser(bytes.NewReader(chunk))
 	m.restoreChunkIndex++
 
 	if int(m.restoreChunkIndex) >= len(m.restoreChunkHashes) {

--- a/snapshots/store_test.go
+++ b/snapshots/store_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,10 +20,10 @@ import (
 )
 
 func setupStore(t *testing.T) *snapshots.Store {
-	// ioutil.TempDir() is used instead of testing.T.TempDir()
+	// os.MkdirTemp() is used instead of testing.T.TempDir()
 	// see https://github.com/cosmos/cosmos-sdk/pull/8475 for
 	// this change's rationale.
-	tempdir, err := ioutil.TempDir("", "")
+	tempdir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(tempdir) })
 
@@ -196,7 +195,7 @@ func TestStore_Load(t *testing.T) {
 	for i := uint32(0); i < snapshot.Chunks; i++ {
 		reader, ok := <-chunks
 		require.True(t, ok)
-		chunk, err := ioutil.ReadAll(reader)
+		chunk, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		err = reader.Close()
 		require.NoError(t, err)
@@ -221,7 +220,7 @@ func TestStore_LoadChunk(t *testing.T) {
 	chunk, err = store.LoadChunk(2, 1, 0)
 	require.NoError(t, err)
 	require.NotNil(t, chunk)
-	body, err := ioutil.ReadAll(chunk)
+	body, err := io.ReadAll(chunk)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{2, 1, 0}, body)
 	err = chunk.Close()
@@ -315,7 +314,7 @@ func TestStore_Save(t *testing.T) {
 
 	ch := make(chan io.ReadCloser, 2)
 	ch <- pr
-	ch <- ioutil.NopCloser(bytes.NewBuffer([]byte{0xff}))
+	ch <- io.NopCloser(bytes.NewBuffer([]byte{0xff}))
 	close(ch)
 
 	_, err = store.Save(6, 1, ch)

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -45,8 +44,8 @@ func ApplyMockIODiscardOutErr(c *cobra.Command) BufferReader {
 	mockIn := strings.NewReader("")
 
 	c.SetIn(mockIn)
-	c.SetOut(ioutil.Discard)
-	c.SetErr(ioutil.Discard)
+	c.SetOut(io.Discard)
+	c.SetErr(io.Discard)
 
 	return mockIn
 }
@@ -68,7 +67,7 @@ func WriteToNewTempFile(t testing.TB, s string) *os.File {
 func TempFile(t testing.TB) *os.File {
 	t.Helper()
 
-	fp, err := ioutil.TempFile(t.TempDir(), "")
+	fp, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 
 	return fp

--- a/testutil/ioutil_test.go
+++ b/testutil/ioutil_test.go
@@ -1,7 +1,8 @@
 package testutil_test
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -28,7 +29,7 @@ func TestWriteToNewTempFile(t *testing.T) {
 	tempfile := testutil.WriteToNewTempFile(t, "test string")
 	tempfile.Close()
 
-	bs, err := ioutil.ReadFile(tempfile.Name())
+	bs, err := os.ReadFile(tempfile.Name())
 	require.NoError(t, err)
 	require.Equal(t, "test string", string(bs))
 }
@@ -39,6 +40,6 @@ func TestApplyMockIODiscardOutErr(t *testing.T) {
 
 	testutil.ApplyMockIODiscardOutErr(cmd)
 	require.NotEqual(t, cmd.InOrStdin(), oldStdin)
-	require.Equal(t, cmd.OutOrStdout(), ioutil.Discard)
-	require.Equal(t, cmd.ErrOrStderr(), ioutil.Discard)
+	require.Equal(t, cmd.OutOrStdout(), io.Discard)
+	require.Equal(t, cmd.ErrOrStderr(), io.Discard)
 }

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -175,7 +174,7 @@ func New(t *testing.T, cfg Config) *Network {
 	t.Log("acquiring test network lock")
 	lock.Lock()
 
-	baseDir, err := ioutil.TempDir(t.TempDir(), cfg.ChainID)
+	baseDir, err := os.MkdirTemp(t.TempDir(), cfg.ChainID)
 	require.NoError(t, err)
 	t.Logf("created temporary directory: %s", baseDir)
 

--- a/testutil/rest.go
+++ b/testutil/rest.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -25,7 +25,7 @@ func GetRequestWithHeaders(url string, headers map[string]string) ([]byte, error
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/testutil/rest/rest.go
+++ b/testutil/rest/rest.go
@@ -5,7 +5,7 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -18,7 +18,7 @@ func GetRequest(url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func PostRequest(url string, contentType string, data []byte) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	bz, err := ioutil.ReadAll(res.Body)
+	bz, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}

--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -135,7 +135,7 @@ func (br BaseReq) ValidateBasic(w http.ResponseWriter) bool {
 // ReadRESTReq reads and unmarshals a Request's body to the the BaseReq struct.
 // Writes an error response to ResponseWriter and returns false if errors occurred.
 func ReadRESTReq(w http.ResponseWriter, r *http.Request, cdc *codec.LegacyAmino, req interface{}) bool {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if CheckBadRequestError(w, err) {
 		return false
 	}
@@ -416,7 +416,7 @@ func GetRequest(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +436,7 @@ func PostRequest(url string, contentType string, data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("error while sending post request: %w", err)
 	}
 
-	bz, err := ioutil.ReadAll(res.Body)
+	bz, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}

--- a/types/rest/rest_test.go
+++ b/types/rest/rest_test.go
@@ -3,7 +3,6 @@ package rest_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -226,7 +225,7 @@ func TestProcessPostResponse(t *testing.T) {
 
 func TestReadRESTReq(t *testing.T) {
 	t.Parallel()
-	reqBody := ioutil.NopCloser(strings.NewReader(`{"chain_id":"alessio","memo":"text"}`))
+	reqBody := io.NopCloser(strings.NewReader(`{"chain_id":"alessio","memo":"text"}`))
 	req := &http.Request{Body: reqBody}
 	w := httptest.NewRecorder()
 	var br rest.BaseReq
@@ -239,7 +238,7 @@ func TestReadRESTReq(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	// test non valid JSON
-	reqBody = ioutil.NopCloser(strings.NewReader(`MALFORMED`))
+	reqBody = io.NopCloser(strings.NewReader(`MALFORMED`))
 	req = &http.Request{Body: reqBody}
 	br = rest.BaseReq{}
 	w = httptest.NewRecorder()
@@ -257,7 +256,7 @@ func TestWriteSimulationResponse(t *testing.T) {
 	res := w.Result() //nolint:bodyclose
 	t.Cleanup(func() { res.Body.Close() })
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	bs, err := ioutil.ReadAll(res.Body)
+	bs, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	t.Cleanup(func() { res.Body.Close() })
 	require.Equal(t, `{"gas_estimate":"10"}`, string(bs))
@@ -320,7 +319,7 @@ func TestPostProcessResponseBare(t *testing.T) {
 	res := w.Result() //nolint:bodyclose
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	got, err := ioutil.ReadAll(res.Body)
+	got, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	t.Cleanup(func() { res.Body.Close() })
@@ -338,7 +337,7 @@ func TestPostProcessResponseBare(t *testing.T) {
 	res = w.Result() //nolint:bodyclose
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	got, err = ioutil.ReadAll(res.Body)
+	got, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	t.Cleanup(func() { res.Body.Close() })
@@ -356,7 +355,7 @@ func TestPostProcessResponseBare(t *testing.T) {
 	res = w.Result() //nolint:bodyclose
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	got, err = ioutil.ReadAll(res.Body)
+	got, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	t.Cleanup(func() { res.Body.Close() })
@@ -371,7 +370,7 @@ func TestPostProcessResponseBare(t *testing.T) {
 	res = w.Result() //nolint:bodyclose
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 
-	got, err = ioutil.ReadAll(res.Body)
+	got, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	t.Cleanup(func() { res.Body.Close() })
@@ -398,7 +397,7 @@ func runPostProcessResponse(t *testing.T, ctx client.Context, obj interface{}, e
 	resp := w.Result() //nolint:bodyclose
 	t.Cleanup(func() { resp.Body.Close() })
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.Nil(t, err)
 	require.Equal(t, expectedBody, body)
 
@@ -413,7 +412,7 @@ func runPostProcessResponse(t *testing.T, ctx client.Context, obj interface{}, e
 	resp = w.Result() //nolint:bodyclose
 
 	t.Cleanup(func() { resp.Body.Close() })
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 
 	require.Nil(t, err)
 	require.Equal(t, string(expectedBody), string(body))

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -376,14 +375,14 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 
 func unmarshalSignatureJSON(clientCtx client.Context, filename string) (sigs []signingtypes.SignatureV2, err error) {
 	var bytes []byte
-	if bytes, err = ioutil.ReadFile(filename); err != nil {
+	if bytes, err = os.ReadFile(filename); err != nil {
 		return
 	}
 	return clientCtx.TxConfig.UnmarshalSignatureJSON(bytes)
 }
 
 func readSignaturesFromFile(ctx client.Context, filename string) (sigs []signingtypes.SignatureV2, err error) {
-	bz, err := ioutil.ReadFile(filename)
+	bz, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/x/auth/client/rest/decode.go
+++ b/x/auth/client/rest/decode.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/line/lbm-sdk/client"
@@ -31,7 +31,7 @@ func DecodeTxRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req DecodeReq
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if rest.CheckBadRequestError(w, err) {
 			return
 		}

--- a/x/auth/client/testutil/suite.go
+++ b/x/auth/client/testutil/suite.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -200,7 +200,7 @@ func (s *IntegrationTestSuite) TestCLISignAminoJSON() {
 	fileFlag := fmt.Sprintf("--%s=%s", flags.FlagOutputDocument, filenameSigned)
 	_, err = TxSignExec(val1.ClientCtx, val1.Address, fileUnsigned.Name(), chainFlag, fileFlag, signModeAminoFlag)
 	require.NoError(err)
-	fContent, err := ioutil.ReadFile(filenameSigned)
+	fContent, err := os.ReadFile(filenameSigned)
 	require.NoError(err)
 	require.Equal(res.String(), string(fContent))
 

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -97,9 +96,9 @@ func ReadTxFromFile(ctx client.Context, filename string) (tx sdk.Tx, err error) 
 	var bytes []byte
 
 	if filename == "-" {
-		bytes, err = ioutil.ReadAll(os.Stdin)
+		bytes, err = io.ReadAll(os.Stdin)
 	} else {
-		bytes, err = ioutil.ReadFile(filename)
+		bytes, err = os.ReadFile(filename)
 	}
 
 	if err != nil {

--- a/x/distribution/client/cli/utils.go
+++ b/x/distribution/client/cli/utils.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/line/lbm-sdk/codec"
 	"github.com/line/lbm-sdk/x/distribution/types"
@@ -11,7 +11,7 @@ import (
 func ParseCommunityPoolSpendProposalWithDeposit(cdc codec.JSONCodec, proposalFile string) (types.CommunityPoolSpendProposalWithDeposit, error) {
 	proposal := types.CommunityPoolSpendProposalWithDeposit{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -223,7 +222,7 @@ func makeOutputFilepath(rootDir, nodeID string) (string, error) {
 }
 
 func readUnsignedGenTxFile(clientCtx client.Context, r io.Reader) (sdk.Tx, error) {
-	bz, err := ioutil.ReadAll(r)
+	bz, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/x/genutil/collect.go
+++ b/x/genutil/collect.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -79,8 +78,8 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 		return appGenTxs, persistentPeers, err
 	}
 
-	var fos []os.FileInfo
-	fos, err = ioutil.ReadDir(genTxsDir)
+	var fos []os.DirEntry
+	fos, err = os.ReadDir(genTxsDir)
 	if err != nil {
 		return appGenTxs, persistentPeers, err
 	}
@@ -107,7 +106,7 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 		}
 
 		// get the genTx
-		jsonRawTx, err := ioutil.ReadFile(filepath.Join(genTxsDir, fo.Name()))
+		jsonRawTx, err := os.ReadFile(filepath.Join(genTxsDir, fo.Name()))
 		if err != nil {
 			return appGenTxs, persistentPeers, err
 		}

--- a/x/genutil/collect_test.go
+++ b/x/genutil/collect_test.go
@@ -2,7 +2,6 @@ package genutil_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func (dni *doNothingIterator) IterateGenesisBalances(_ codec.JSONCodec, _ map[st
 // Ensures that CollectTx correctly traverses directories and won't error out on encountering
 // a directory during traversal of the first level. See issue https://github.com/cosmos/cosmos-sdk/issues/6788.
 func TestCollectTxsHandlesDirectories(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "testCollectTxs")
+	testDir, err := os.MkdirTemp(os.TempDir(), "testCollectTxs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x/gov/client/cli/parse.go
+++ b/x/gov/client/cli/parse.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/pflag"
 
@@ -54,7 +54,7 @@ func parseSubmitProposalFlags(fs *pflag.FlagSet) (*proposal, error) {
 		}
 	}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return nil, err
 	}

--- a/x/ibc/applications/transfer/keeper/mbt_relay_test.go
+++ b/x/ibc/applications/transfer/keeper/mbt_relay_test.go
@@ -7,7 +7,7 @@ package keeper_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -275,7 +275,7 @@ func (suite *KeeperTestSuite) CheckBankBalances(chain *ibctesting.TestChain, ban
 
 func (suite *KeeperTestSuite) TestModelBasedRelay() {
 	dirname := "model_based_tests/"
-	files, err := ioutil.ReadDir(dirname)
+	files, err := os.ReadDir(dirname)
 	if err != nil {
 		panic(fmt.Errorf("Failed to read model-based test files: %w", err))
 	}
@@ -284,7 +284,7 @@ func (suite *KeeperTestSuite) TestModelBasedRelay() {
 		if !strings.HasSuffix(file_info.Name(), ".json") {
 			continue
 		}
-		jsonBlob, err := ioutil.ReadFile(dirname + file_info.Name())
+		jsonBlob, err := os.ReadFile(dirname + file_info.Name())
 		if err != nil {
 			panic(fmt.Errorf("Failed to read JSON test fixture: %w", err))
 		}

--- a/x/ibc/core/02-client/client/cli/tx.go
+++ b/x/ibc/core/02-client/client/cli/tx.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/line/lbm-sdk/client"
@@ -43,7 +43,7 @@ func NewCreateClientCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(clientContentOrFileName), &clientState); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(clientContentOrFileName)
+				contents, err := os.ReadFile(clientContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for client state were provided: %w", err)
 				}
@@ -59,7 +59,7 @@ func NewCreateClientCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(consensusContentOrFileName), &consensusState); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(consensusContentOrFileName)
+				contents, err := os.ReadFile(consensusContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for consensus state were provided: %w", err)
 				}
@@ -105,7 +105,7 @@ func NewUpdateClientCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(headerContentOrFileName), &header); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(headerContentOrFileName)
+				contents, err := os.ReadFile(headerContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for header were provided: %w", err)
 				}
@@ -146,7 +146,7 @@ func NewSubmitMisbehaviourCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(misbehaviourContentOrFileName), &misbehaviour); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(misbehaviourContentOrFileName)
+				contents, err := os.ReadFile(misbehaviourContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for misbehaviour were provided: %w", err)
 				}
@@ -190,7 +190,7 @@ func NewUpgradeClientCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(clientContentOrFileName), &clientState); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(clientContentOrFileName)
+				contents, err := os.ReadFile(clientContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for client state were provided: %w", err)
 				}
@@ -206,7 +206,7 @@ func NewUpgradeClientCmd() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(consensusContentOrFileName), &consensusState); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(consensusContentOrFileName)
+				contents, err := os.ReadFile(consensusContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for consensus state were provided: %w", err)
 				}
@@ -347,7 +347,7 @@ func NewCmdSubmitUpgradeProposal() *cobra.Command {
 			if err := cdc.UnmarshalInterfaceJSON([]byte(clientContentOrFileName), &clientState); err != nil {
 
 				// check for file path if JSON input is not provided
-				contents, err := ioutil.ReadFile(clientContentOrFileName)
+				contents, err := os.ReadFile(clientContentOrFileName)
 				if err != nil {
 					return fmt.Errorf("neither JSON input nor path to .json file for client state were provided: %w", err)
 				}

--- a/x/ibc/core/03-connection/client/utils/utils.go
+++ b/x/ibc/core/03-connection/client/utils/utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/lbm-sdk/client"
 	"github.com/line/lbm-sdk/codec"
@@ -171,7 +171,7 @@ func ParseClientState(cdc *codec.LegacyAmino, arg string) (exported.ClientState,
 	var clientState exported.ClientState
 	if err := cdc.UnmarshalJSON([]byte(arg), &clientState); err != nil {
 		// check for file path if JSON input is not provided
-		contents, err := ioutil.ReadFile(arg)
+		contents, err := os.ReadFile(arg)
 		if err != nil {
 			return nil, errors.New("either JSON input nor path to .json file were provided")
 		}
@@ -188,7 +188,7 @@ func ParsePrefix(cdc *codec.LegacyAmino, arg string) (commitmenttypes.MerklePref
 	var prefix commitmenttypes.MerklePrefix
 	if err := cdc.UnmarshalJSON([]byte(arg), &prefix); err != nil {
 		// check for file path if JSON input is not provided
-		contents, err := ioutil.ReadFile(arg)
+		contents, err := os.ReadFile(arg)
 		if err != nil {
 			return commitmenttypes.MerklePrefix{}, errors.New("neither JSON input nor path to .json file were provided")
 		}
@@ -206,7 +206,7 @@ func ParseProof(cdc *codec.LegacyAmino, arg string) ([]byte, error) {
 	var merkleProof commitmenttypes.MerkleProof
 	if err := cdc.UnmarshalJSON([]byte(arg), &merkleProof); err != nil {
 		// check for file path if JSON input is not provided
-		contents, err := ioutil.ReadFile(arg)
+		contents, err := os.ReadFile(arg)
 		if err != nil {
 			return nil, errors.New("neither JSON input nor path to .json file were provided")
 		}

--- a/x/params/client/utils/utils.go
+++ b/x/params/client/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/lbm-sdk/codec"
 	sdk "github.com/line/lbm-sdk/types"
@@ -68,7 +68,7 @@ func (pcj ParamChangesJSON) ToParamChanges() []proposal.ParamChange {
 func ParseParamChangeProposalJSON(cdc *codec.LegacyAmino, proposalFile string) (ParamChangeProposalJSON, error) {
 	proposal := ParamChangeProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err
 	}

--- a/x/simulation/event_stats.go
+++ b/x/simulation/event_stats.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // EventStats defines an object that keeps a tally of each event that has occurred
@@ -48,7 +48,7 @@ func (es EventStats) ExportJSON(path string) {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(path, bz, 0600)
+	err = os.WriteFile(path, bz, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/x/upgrade/abci_test.go
+++ b/x/upgrade/abci_test.go
@@ -3,7 +3,6 @@ package upgrade_test
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -395,7 +394,7 @@ func TestDumpUpgradeInfoToFile(t *testing.T) {
 	upgradeInfoFilePath, err := s.keeper.GetUpgradeInfoPath()
 	require.Nil(t, err)
 
-	data, err := ioutil.ReadFile(upgradeInfoFilePath)
+	data, err := os.ReadFile(upgradeInfoFilePath)
 	require.NoError(t, err)
 
 	var upgradeInfo storetypes.UpgradeInfo

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -428,7 +427,7 @@ func (k Keeper) ReadUpgradeInfoFromDisk() (store.UpgradeInfo, error) {
 		return upgradeInfo, err
 	}
 
-	data, err := ioutil.ReadFile(upgradeInfoPath)
+	data, err := os.ReadFile(upgradeInfoPath)
 	if err != nil {
 		// if file does not exist, assume there are no upgrades
 		if os.IsNotExist(err) {

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +76,7 @@ func TestSetLoader(t *testing.T) {
 	data, err := json.Marshal(upgradeInfo)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(upgradeInfoFilePath, data, 0644)
+	err = os.WriteFile(upgradeInfoFilePath, data, 0644)
 	require.NoError(t, err)
 
 	// make sure it exists before running everything

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -43,7 +42,7 @@ func TestGenesisStoreCodeCmd(t *testing.T) {
 	minimalWasmGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 	}
-	anyValidWasmFile, err := ioutil.TempFile(t.TempDir(), "wasm")
+	anyValidWasmFile, err := os.CreateTemp(t.TempDir(), "wasm")
 	require.NoError(t, err)
 	anyValidWasmFile.Write(wasmIdent)
 	require.NoError(t, anyValidWasmFile.Close())
@@ -110,7 +109,7 @@ func TestInstantiateContractCmd(t *testing.T) {
 	minimalWasmGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 	}
-	anyValidWasmFile, err := ioutil.TempFile(t.TempDir(), "wasm")
+	anyValidWasmFile, err := os.CreateTemp(t.TempDir(), "wasm")
 	require.NoError(t, err)
 	anyValidWasmFile.Write(wasmIdent)
 	require.NoError(t, anyValidWasmFile.Close())
@@ -369,7 +368,7 @@ func TestExecuteContractCmd(t *testing.T) {
 	minimalWasmGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 	}
-	anyValidWasmFile, err := ioutil.TempFile(t.TempDir(), "wasm")
+	anyValidWasmFile, err := os.CreateTemp(t.TempDir(), "wasm")
 	require.NoError(t, err)
 	anyValidWasmFile.Write(wasmIdent)
 	require.NoError(t, anyValidWasmFile.Close())

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	wasmvm "github.com/line/wasmvm"
@@ -177,7 +177,7 @@ func GetCmdQueryCode() *cobra.Command {
 			}
 
 			fmt.Printf("Downloading wasm code to %s\n", args[1])
-			return ioutil.WriteFile(args[1], res.Data, 0600)
+			return os.WriteFile(args[1], res.Data, 0600)
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)

--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -82,7 +82,7 @@ func StoreCodeCmd() *cobra.Command {
 }
 
 func parseStoreCodeArgs(file string, sender sdk.AccAddress, flags *flag.FlagSet) (types.MsgStoreCode, error) {
-	wasm, err := ioutil.ReadFile(file)
+	wasm, err := os.ReadFile(file)
 	if err != nil {
 		return types.MsgStoreCode{}, err
 	}
@@ -264,7 +264,7 @@ func StoreCodeAndInstantiateContractCmd() *cobra.Command {
 }
 
 func parseStoreCodeAndInstantiateContractArgs(file string, initMsg string, sender sdk.AccAddress, flags *flag.FlagSet) (lbmtypes.MsgStoreCodeAndInstantiateContract, error) {
-	wasm, err := ioutil.ReadFile(file)
+	wasm, err := os.ReadFile(file)
 	if err != nil {
 		return lbmtypes.MsgStoreCodeAndInstantiateContract{}, err
 	}

--- a/x/wasm/client/testutil/suite.go
+++ b/x/wasm/client/testutil/suite.go
@@ -2,7 +2,7 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/line/lbm-sdk/client/flags"
@@ -56,7 +56,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	// add inactive contract to genesis
 	var wasmData types.GenesisState
 	genesisState := s.cfg.GenesisState
-	genesisData, err := ioutil.ReadFile("./testdata/wasm_genesis.json")
+	genesisData, err := os.ReadFile("./testdata/wasm_genesis.json")
 	s.Require().NoError(err)
 	s.Require().NoError(s.cfg.Codec.UnmarshalJSON(genesisData, &wasmData))
 	wasmDataBz, err := s.cfg.Codec.MarshalJSON(&wasmData)
@@ -99,7 +99,7 @@ func (s *IntegrationTestSuite) deployContract() string {
 	val := s.network.Validators[0]
 
 	wasmPath := "../../keeper/testdata/hackatom.wasm"
-	_, err := ioutil.ReadFile(wasmPath)
+	_, err := os.ReadFile(wasmPath)
 	s.Require().NoError(err)
 
 	args := append([]string{

--- a/x/wasm/client/testutil/tx.go
+++ b/x/wasm/client/testutil/tx.go
@@ -2,7 +2,7 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/lbm-sdk/client/flags"
 	clitestutil "github.com/line/lbm-sdk/testutil/cli"
@@ -171,7 +171,7 @@ func (s *IntegrationTestSuite) TestStoreCodeAndInstantiateContractCmd() {
 	owner := val.Address.String()
 
 	wasmPath := "../../keeper/testdata/hackatom.wasm"
-	_, err := ioutil.ReadFile(wasmPath)
+	_, err := os.ReadFile(wasmPath)
 	s.Require().NoError(err)
 
 	params := fmt.Sprintf("{\"verifier\": \"%s\", \"beneficiary\": \"%s\"}", s.network.Validators[0].Address.String(), keeper.RandomAccountAddress(s.T()))

--- a/x/wasm/client/testutil/tx.go
+++ b/x/wasm/client/testutil/tx.go
@@ -211,6 +211,17 @@ func (s *IntegrationTestSuite) TestStoreCodeAndInstantiateContractCmd() {
 			},
 			false,
 		},
+		"wrong wasm path error": {
+			[]string{
+				"../../keeper/testdata/noexist.wasm",
+				params,
+				fmt.Sprintf("--label=%s", "TestContract"),
+				fmt.Sprintf("--admin=%s", owner),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				fmt.Sprintf("--%s=%d", flags.FlagGas, 1600000),
+			},
+			false,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/x/wasm/ibctesting/wasm.go
+++ b/x/wasm/ibctesting/wasm.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	simapp "github.com/line/lbm-sdk/simapp"
@@ -37,7 +37,7 @@ func (chain *TestChain) SeedNewContractInstance() sdk.AccAddress {
 }
 
 func (chain *TestChain) StoreCodeFile(filename string) types.MsgStoreCodeResponse {
-	wasmCode, err := ioutil.ReadFile(filename)
+	wasmCode, err := os.ReadFile(filename)
 	require.NoError(chain.t, err)
 	if strings.HasSuffix(filename, "wasm") { // compress for gas limit
 		var buf bytes.Buffer

--- a/x/wasm/ioutils/ioutil.go
+++ b/x/wasm/ioutils/ioutil.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 
 	"github.com/line/lbm-sdk/x/wasm/types"
 )
@@ -26,7 +25,7 @@ func Uncompress(src []byte, limit uint64) ([]byte, error) {
 	}
 	zr.Multistream(false)
 	defer zr.Close()
-	return ioutil.ReadAll(LimitReader(zr, int64(limit)))
+	return io.ReadAll(LimitReader(zr, int64(limit)))
 }
 
 // LimitReader returns a Reader that reads from r

--- a/x/wasm/ioutils/ioutil_test.go
+++ b/x/wasm/ioutils/ioutil_test.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -16,10 +16,10 @@ import (
 )
 
 func TestUncompress(t *testing.T) {
-	wasmRaw, err := ioutil.ReadFile("../keeper/testdata/hackatom.wasm")
+	wasmRaw, err := os.ReadFile("../keeper/testdata/hackatom.wasm")
 	require.NoError(t, err)
 
-	wasmGzipped, err := ioutil.ReadFile("../keeper/testdata/hackatom.wasm.gzip")
+	wasmGzipped, err := os.ReadFile("../keeper/testdata/hackatom.wasm.gzip")
 	require.NoError(t, err)
 
 	const maxSize = 400_000

--- a/x/wasm/ioutils/utils_test.go
+++ b/x/wasm/ioutils/utils_test.go
@@ -1,14 +1,14 @@
 package ioutils
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func GetTestData() ([]byte, []byte, []byte, error) {
-	wasmCode, err := ioutil.ReadFile("../keeper/testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("../keeper/testdata/hackatom.wasm")
 
 	if err != nil {
 		return nil, nil, nil, err

--- a/x/wasm/keeper/bench_test.go
+++ b/x/wasm/keeper/bench_test.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -108,7 +108,7 @@ func BenchmarkCompilation(b *testing.B) {
 			ctx, keepers := createTestInput(b, false, SupportedFeatures, nil, nil, wasmConfig, spec.db())
 
 			// print out code size for comparisons
-			code, err := ioutil.ReadFile(spec.wasmFile)
+			code, err := os.ReadFile(spec.wasmFile)
 			require.NoError(b, err)
 			b.Logf("\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b(size: %d)  ", len(code))
 

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -41,7 +40,7 @@ func TestGenesisExportImport(t *testing.T) {
 	wasmKeeper, srcCtx, srcStoreKeys := setupKeeper(t)
 	contractKeeper := NewGovPermissionKeeper(wasmKeeper)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	// store some test data
@@ -154,7 +153,7 @@ func TestGenesisExportImport(t *testing.T) {
 }
 
 func TestGenesisInit(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	myCodeInfo := wasmTypes.CodeInfoFixture(wasmTypes.WithSHA256CodeHash(wasmCode))
@@ -500,7 +499,7 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
 	keeper, ctx, _ := setupKeeper(t)
 	contractKeeper := NewGovPermissionKeeper(keeper)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	wasmCodeHash := sha256.Sum256(wasmCode)
@@ -566,7 +565,7 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
 }
 
 func TestSupportedGenMsgTypes(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 	var (
 		myAddress          sdk.AccAddress = bytes.Repeat([]byte{1}, types.ContractAddrLen)
@@ -638,7 +637,7 @@ func TestSupportedGenMsgTypes(t *testing.T) {
 
 func setupKeeper(t *testing.T) (*Keeper, sdk.Context, []sdk.StoreKey) {
 	t.Helper()
-	tempDir, err := ioutil.TempDir("", "wasm")
+	tempDir, err := os.MkdirTemp("", "wasm")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(tempDir) })
 	var (

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -28,7 +28,7 @@ import (
 
 // When migrated to go 1.16, embed package should be used instead.
 func init() {
-	b, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	b, err := os.ReadFile("./testdata/hackatom.wasm")
 	if err != nil {
 		panic(err)
 	}
@@ -348,7 +348,7 @@ func TestCreateWithGzippedPayload(t *testing.T) {
 	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm.gzip")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm.gzip")
 	require.NoError(t, err, "reading gzipped WASM code")
 
 	contractID, err := keeper.Create(ctx, creator, wasmCode, nil)
@@ -1084,7 +1084,7 @@ func TestMigrateWithDispatchedMessage(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit.Add(deposit...)...)
 	fred := keepers.Faucet.NewFundedAccount(ctx, sdk.NewInt64Coin("denom", 5000))
 
-	burnerCode, err := ioutil.ReadFile("./testdata/burner.wasm")
+	burnerCode, err := os.ReadFile("./testdata/burner.wasm")
 	require.NoError(t, err)
 
 	originalContractID, err := keeper.Create(ctx, creator, hackatomWasm, nil)
@@ -1469,7 +1469,7 @@ func TestExecuteManualInactiveContractFailure(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 	fred := keepers.Faucet.NewFundedAccount(ctx, topUp...)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	contractID, err := keeper.Create(ctx, creator, wasmCode, nil)

--- a/x/wasm/keeper/legacy_querier_test.go
+++ b/x/wasm/keeper/legacy_querier_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	abci "github.com/line/ostracon/abci/types"
@@ -24,7 +24,7 @@ func TestLegacyQueryContractState(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit.Add(deposit...)...)
 	anyAddr := keepers.Faucet.NewFundedAccount(ctx, sdk.NewInt64Coin("denom", 5000))
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	contractID, err := keepers.ContractKeeper.Create(ctx, creator, wasmCode, nil)
@@ -162,7 +162,7 @@ func TestLegacyQueryContractListByCodeOrdering(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit.Add(deposit...)...)
 	anyAddr := keepers.Faucet.NewFundedAccount(ctx, topUp...)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, wasmCode, nil)
@@ -312,7 +312,7 @@ func TestLegacyQueryContractHistory(t *testing.T) {
 }
 
 func TestLegacyQueryCodeList(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	specs := map[string]struct {

--- a/x/wasm/keeper/proposal_integration_test.go
+++ b/x/wasm/keeper/proposal_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	wasmvm "github.com/line/wasmvm"
@@ -31,7 +31,7 @@ func TestStoreCodeProposal(t *testing.T) {
 		InstanceCost:                 types.DefaultInstanceCost,
 		CompileCost:                  types.DefaultCompileCost,
 	})
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	myActorAddress := RandomBech32AccountAddress(t)
@@ -72,7 +72,7 @@ func TestInstantiateProposal(t *testing.T) {
 		CompileCost:                  types.DefaultCompileCost,
 	})
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	require.NoError(t, wasmKeeper.importCode(ctx, 1,
@@ -140,7 +140,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 		CompileCost:                  types.DefaultCompileCost,
 	})
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	require.NoError(t, wasmKeeper.importCode(ctx, 1,
@@ -215,7 +215,7 @@ func TestMigrateProposal(t *testing.T) {
 		CompileCost:                  types.DefaultCompileCost,
 	})
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	codeInfoFixture := types.CodeInfoFixture(types.WithSHA256CodeHash(wasmCode))
@@ -406,7 +406,7 @@ func TestAdminProposals(t *testing.T) {
 		otherAddress sdk.AccAddress = bytes.Repeat([]byte{0x2}, types.ContractAddrLen)
 		contractAddr                = BuildContractAddress(1, 1)
 	)
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	specs := map[string]struct {

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -265,7 +265,7 @@ func TestQueryContractListByCodeOrdering(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 	anyAddr := keepers.Faucet.NewFundedAccount(ctx, topUp...)
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, wasmCode, nil)
@@ -454,7 +454,7 @@ func TestQueryContractHistory(t *testing.T) {
 }
 
 func TestQueryCode(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
@@ -507,7 +507,7 @@ func TestQueryCode(t *testing.T) {
 }
 
 func TestQueryCodeList(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
@@ -724,7 +724,7 @@ func TestQueryPinnedCodes(t *testing.T) {
 }
 
 func TestQueryCodeInfo(t *testing.T) {
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
@@ -780,7 +780,7 @@ func TestQueryCodeInfo(t *testing.T) {
 
 func TestQueryCodeInfoList(t *testing.T) {
 
-	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)

--- a/x/wasm/keeper/reflect_test.go
+++ b/x/wasm/keeper/reflect_test.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -94,14 +94,14 @@ func TestReflectContractSend(t *testing.T) {
 	_, _, bob := keyPubAddr()
 
 	// upload reflect code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	reflectID, err := keeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), reflectID)
 
 	// upload hackatom escrow code
-	escrowCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	escrowCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 	escrowID, err := keeper.Create(ctx, creator, escrowCode, nil)
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestReflectCustomMsg(t *testing.T) {
 	_, _, fred := keyPubAddr()
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -267,7 +267,7 @@ func TestMaskReflectCustomQuery(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -319,7 +319,7 @@ func TestReflectStargateQuery(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, funds...)
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestReflectInvalidStargateQuery(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, funds...)
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -443,7 +443,7 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload reflect code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	reflectID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -515,7 +515,7 @@ func TestWasmRawQueryWithNil(t *testing.T) {
 	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload reflect code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	reflectID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)

--- a/x/wasm/keeper/snapshotter_integration_test.go
+++ b/x/wasm/keeper/snapshotter_integration_test.go
@@ -2,7 +2,7 @@ package keeper_test
 
 import (
 	"crypto/sha256"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -54,7 +54,7 @@ func TestSnapshotter(t *testing.T) {
 
 			srcCodeIDToChecksum := make(map[uint64][]byte, len(spec.wasmFiles))
 			for i, v := range spec.wasmFiles {
-				wasmCode, err := ioutil.ReadFile(v)
+				wasmCode, err := os.ReadFile(v)
 				require.NoError(t, err)
 				codeID, err := contractKeeper.Create(ctx, genesisAddr, wasmCode, nil)
 				require.NoError(t, err)

--- a/x/wasm/keeper/staking_test.go
+++ b/x/wasm/keeper/staking_test.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	wasmtypes "github.com/line/lbm-sdk/x/wasm/types"
@@ -106,7 +106,7 @@ func TestInitializeStaking(t *testing.T) {
 	creator := k.Faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload staking derivates code
-	stakingCode, err := ioutil.ReadFile("./testdata/staking.wasm")
+	stakingCode, err := os.ReadFile("./testdata/staking.wasm")
 	require.NoError(t, err)
 	stakingID, err := keeper.Create(ctx, creator, stakingCode, nil)
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func initializeStaking(t *testing.T) initInfo {
 	creator := k.Faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload staking derivates code
-	stakingCode, err := ioutil.ReadFile("./testdata/staking.wasm")
+	stakingCode, err := os.ReadFile("./testdata/staking.wasm")
 	require.NoError(t, err)
 	stakingID, err := k.ContractKeeper.Create(ctx, creator, stakingCode, nil)
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func TestQueryStakingInfo(t *testing.T) {
 	creator := initInfo.faucet.NewFundedAccount(ctx, deposit...)
 
 	// upload mask code
-	maskCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	maskCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	maskID, err := initInfo.contractKeeper.Create(ctx, creator, maskCode, nil)
 	require.NoError(t, err)

--- a/x/wasm/keeper/submsg_test.go
+++ b/x/wasm/keeper/submsg_test.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestDispatchSubMsgSuccessCase(t *testing.T) {
 	_, _, fred := keyPubAddr()
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -122,13 +122,13 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 	uploader := keepers.Faucet.NewFundedAccount(ctx, contractStart.Add(contractStart...)...)
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	reflectID, err := keepers.ContractKeeper.Create(ctx, uploader, reflectCode, nil)
 	require.NoError(t, err)
 
 	// create hackatom contract for testing (for infinite loop)
-	hackatomCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
+	hackatomCode, err := os.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 	hackatomID, err := keepers.ContractKeeper.Create(ctx, uploader, hackatomCode, nil)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestDispatchSubMsgEncodeToNoSdkMsg(t *testing.T) {
 	_, _, fred := keyPubAddr()
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)
@@ -449,7 +449,7 @@ func TestDispatchSubMsgConditionalReplyOn(t *testing.T) {
 	_, _, fred := keyPubAddr()
 
 	// upload code
-	reflectCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	reflectCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 	codeID, err := keepers.ContractKeeper.Create(ctx, creator, reflectCode, nil)
 	require.NoError(t, err)

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -554,7 +554,7 @@ func StoreIBCReflectContract(t testing.TB, ctx sdk.Context, keepers TestKeepers)
 }
 
 func StoreReflectContract(t testing.TB, ctx sdk.Context, keepers TestKeepers) uint64 {
-	wasmCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	wasmCode, err := os.ReadFile("./testdata/reflect.wasm")
 	require.NoError(t, err)
 
 	_, _, creatorAddr := keyPubAddr()
@@ -568,7 +568,7 @@ func StoreExampleContract(t testing.TB, ctx sdk.Context, keepers TestKeepers, wa
 	creator, _, creatorAddr := keyPubAddr()
 	fundAccounts(t, ctx, keepers.AccountKeeper, keepers.BankKeeper, creatorAddr, anyAmount)
 
-	wasmCode, err := ioutil.ReadFile(wasmFile)
+	wasmCode, err := os.ReadFile(wasmFile)
 	require.NoError(t, err)
 
 	codeID, err := keepers.ContractKeeper.Create(ctx, creatorAddr, wasmCode, nil)

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -3,7 +3,7 @@ package wasm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/dvsekhvalnov/jose2go/base64url"
@@ -55,7 +55,7 @@ func keyPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
 }
 
 func mustLoad(path string) []byte {
-	bz, err := ioutil.ReadFile(path)
+	bz, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/x/wasm/simulation/operations.go
+++ b/x/wasm/simulation/operations.go
@@ -1,8 +1,8 @@
 package simulation
 
 import (
-	"io/ioutil"
 	"math/rand"
+	"os"
 
 	"github.com/line/lbm-sdk/baseapp"
 	simappparams "github.com/line/lbm-sdk/simapp/params"
@@ -58,7 +58,7 @@ func WeightedOperations(
 		},
 	)
 
-	wasmBz, err := ioutil.ReadFile(wasmContractPath)
+	wasmBz, err := os.ReadFile(wasmContractPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace deprecated functions since go 1.16 or 1.17.

* ioutil.ReadFile -> os.ReadFile
* ioutil.ReadAll -> io.ReadAll
* ioutil.TempDir -> os.MkdirTemp
* ioutil.WriteFile -> os.WriteFile
* ioutil.NopCloser -> io.NopCloser
* ioutil.Discard -> io.Discard
* ioutil.TempFile -> os.CreateTemp
* ioutil.Discard -> io.Discard
* ioutil.ReadDir -> os.ReadDir

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The io/ioutil has been deprecated since Go 1.16.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
