### PR TITLE
fix: prune stale x/foundation proposals at voting period end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/bankplus) [\#705](https://github.com/line/lbm-sdk/pull/705) add missing blockedAddr checking in bankplus
 * (x/foundation) [\#712](https://github.com/line/lbm-sdk/pull/712) fix x/foundation EndBlocker
 * (x/staking) [\#726](https://github.com/line/lbm-sdk/pull/726) check allowedList size in StakeAuthorization.Accept()
+* (x/foundation) [\#730](https://github.com/line/lbm-sdk/pull/730) prune stale x/foundation proposals at voting period end
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/x/foundation/keeper/abci_test.go
+++ b/x/foundation/keeper/abci_test.go
@@ -66,27 +66,32 @@ func (s *KeeperTestSuite) TestEndBlocker() {
 	keeper.EndBlocker(ctx, s.keeper)
 
 	for name, tc := range map[string]struct {
-		id     uint64
-		status foundation.ProposalStatus
+		id      uint64
+		removed bool
+		status  foundation.ProposalStatus
 	}{
 		"active proposal": {
-			s.activeProposal,
-			foundation.PROPOSAL_STATUS_ACCEPTED,
+			id:     s.activeProposal,
+			status: foundation.PROPOSAL_STATUS_ACCEPTED,
 		},
 		"voted proposal": {
-			s.votedProposal,
-			foundation.PROPOSAL_STATUS_REJECTED,
+			id:     s.votedProposal,
+			status: foundation.PROPOSAL_STATUS_REJECTED,
 		},
 		"withdrawn proposal": {
-			s.withdrawnProposal,
-			foundation.PROPOSAL_STATUS_WITHDRAWN,
+			id:      s.withdrawnProposal,
+			removed: true,
 		},
 		"invalid proposal": {
-			s.invalidProposal,
-			foundation.PROPOSAL_STATUS_ACCEPTED,
+			id:     s.invalidProposal,
+			status: foundation.PROPOSAL_STATUS_ACCEPTED,
 		},
 	} {
 		proposal, err := s.keeper.GetProposal(ctx, tc.id)
+		if tc.removed {
+			s.Require().Error(err, name)
+			continue
+		}
 		s.Require().NoError(err, name)
 		s.Require().NotNil(proposal, name)
 		s.Require().Equal(tc.status, proposal.Status, name)

--- a/x/foundation/keeper/proposal.go
+++ b/x/foundation/keeper/proposal.go
@@ -189,15 +189,25 @@ func (k Keeper) iterateProposalsByVPEnd(ctx sdk.Context, endTime time.Time, fn f
 }
 
 func (k Keeper) UpdateTallyOfVPEndProposals(ctx sdk.Context) {
+	var proposals []foundation.Proposal
 	k.iterateProposalsByVPEnd(ctx, ctx.BlockTime(), func(proposal foundation.Proposal) (stop bool) {
+		proposals = append(proposals, proposal)
+		return false
+	})
+
+	for _, proposal := range proposals {
+		proposal := proposal
+
+		if proposal.Status == foundation.PROPOSAL_STATUS_ABORTED || proposal.Status == foundation.PROPOSAL_STATUS_WITHDRAWN {
+			k.pruneProposal(ctx, proposal)
+			continue
+		}
+
 		if err := k.doTallyAndUpdate(ctx, &proposal); err != nil {
 			panic(err)
 		}
-
 		k.setProposal(ctx, proposal)
-
-		return false
-	})
+	}
 }
 
 func (k Keeper) GetProposal(ctx sdk.Context, id uint64) (*foundation.Proposal, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The specification #721 says aborted and withdrawn proposals must be pruned at their voting period end. This patch addresses the difference in logic from the documentation's.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
