### PR TITLE
fix: add verification on accounts into x/foundation Grants cli

### DIFF
--- a/x/foundation/client/cli/query.go
+++ b/x/foundation/client/cli/query.go
@@ -377,12 +377,18 @@ func NewQueryCmdGrants() *cobra.Command {
 				return err
 			}
 
+			grantee, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
 			msgTypeURL := ""
 			if len(args) >= 2 {
 				msgTypeURL = args[1]
 			}
+
 			params := foundation.QueryGrantsRequest{
-				Grantee:    args[0],
+				Grantee:    grantee.String(),
 				MsgTypeUrl: msgTypeURL,
 				Pagination: pageReq,
 			}

--- a/x/foundation/client/testutil/query.go
+++ b/x/foundation/client/testutil/query.go
@@ -179,6 +179,13 @@ func (s *IntegrationTestSuite) TestNewQueryCmdMember() {
 			false,
 			nil,
 		},
+		"invalid member": {
+			[]string{
+				"",
+			},
+			false,
+			nil,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -262,6 +269,12 @@ func (s *IntegrationTestSuite) TestNewQueryCmdProposal() {
 			[]string{
 				fmt.Sprintf("%d", s.proposalID),
 				"extra",
+			},
+			false,
+		},
+		"invalid id": {
+			[]string{
+				fmt.Sprintf("%d", -1),
 			},
 			false,
 		},
@@ -352,6 +365,20 @@ func (s *IntegrationTestSuite) TestNewQueryCmdVote() {
 			},
 			false,
 		},
+		"invalid proposal id": {
+			[]string{
+				fmt.Sprintf("%d", -1),
+				s.permanentMember.String(),
+			},
+			false,
+		},
+		"invalid voter": {
+			[]string{
+				fmt.Sprintf("%d", s.proposalID),
+				"",
+			},
+			false,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -396,6 +423,12 @@ func (s *IntegrationTestSuite) TestNewQueryCmdVotes() {
 			},
 			false,
 		},
+		"invalid proposal id": {
+			[]string{
+				fmt.Sprintf("%d", -1),
+			},
+			false,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -437,6 +470,12 @@ func (s *IntegrationTestSuite) TestNewQueryCmdTallyResult() {
 			[]string{
 				fmt.Sprintf("%d", s.proposalID),
 				"extra",
+			},
+			false,
+		},
+		"invalid proposal id": {
+			[]string{
+				fmt.Sprintf("%d", -1),
 			},
 			false,
 		},
@@ -492,6 +531,14 @@ func (s *IntegrationTestSuite) TestNewQueryCmdGrants() {
 				s.stranger.String(),
 				foundation.ReceiveFromTreasuryAuthorization{}.MsgTypeURL(),
 				"extra",
+			},
+			false,
+			0,
+		},
+		"invalid grantee": {
+			[]string{
+				"",
+				foundation.ReceiveFromTreasuryAuthorization{}.MsgTypeURL(),
 			},
 			false,
 			0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch will add the verification on grantee in the cli for `x/foundation` `Query/Grants`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
