### PR TITLE
fix: add x/distribution's module account into blockedAddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#730](https://github.com/line/lbm-sdk/pull/730) prune stale x/foundation proposals at voting period end
 * (cli) [\#734](https://github.com/line/lbm-sdk/pull/734) add restrictions on the number of args in the CLIs
 * (client) [\#737](https://github.com/line/lbm-sdk/pull/737) check multisig key list to prevent unexpected key deletion
+* (simapp) [\#752](https://github.com/line/lbm-sdk/pull/752) add x/distribution's module account into blockedAddr
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -191,7 +191,7 @@ var (
 
 	// module accounts that are allowed to receive tokens
 	allowedReceivingModAcc = map[string]bool{
-		distrtypes.ModuleName: true,
+		// govtypes.ModuleName: true, // TODO: uncomment it when authority is ready
 	}
 )
 

--- a/x/bank/keeper/genesis_test.go
+++ b/x/bank/keeper/genesis_test.go
@@ -39,7 +39,7 @@ func (suite *IntegrationTestSuite) TestExportGenesis() {
 
 func (suite *IntegrationTestSuite) getTestBalancesAndSupply() ([]types.Balance, sdk.Coins) {
 	addr2, _ := sdk.AccAddressFromBech32("link1f9xjhxm0plzrh9cskf4qee4pc2xwp0n0p662v8")
-	addr1, _ := sdk.AccAddressFromBech32("link1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8j3y7jh") // distribution module address
+	addr1, _ := sdk.AccAddressFromBech32("link1t5u0jfg3ljsjrh2m9e47d4ny2hea7eehndz0n9")
 	addr1Balance := sdk.Coins{sdk.NewInt64Coin("testcoin3", 10)}
 	addr2Balance := sdk.Coins{sdk.NewInt64Coin("testcoin1", 32), sdk.NewInt64Coin("testcoin2", 34)}
 

--- a/x/bank/simulation/operations_test.go
+++ b/x/bank/simulation/operations_test.go
@@ -143,13 +143,13 @@ func (suite *SimTestSuite) TestSimulateModuleAccountMsgSend() {
 	r = rand.New(s)
 
 	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
-	suite.Require().NoError(err)
+	suite.Require().Error(err)
 
 	var msg types.MsgSend
 	types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 
-	suite.Require().True(operationMsg.OK)
-	suite.Require().Empty(operationMsg.Comment)
+	suite.Require().False(operationMsg.OK)
+	suite.Require().Equal(operationMsg.Comment, "invalid transfers")
 	suite.Require().Equal(types.TypeMsgSend, msg.Type())
 	suite.Require().Equal(types.ModuleName, msg.Route())
 	suite.Require().Len(futureOperations, 0)
@@ -173,13 +173,13 @@ func (suite *SimTestSuite) TestSimulateMsgMultiSendToModuleAccount() {
 	op := simulation.SimulateMsgMultiSendToModuleAccount(suite.app.AccountKeeper, suite.app.BankKeeper, mAccCount)
 
 	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
-	suite.Require().NoError(err)
+	suite.Require().Error(err)
 
 	var msg types.MsgMultiSend
 	types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 
-	suite.Require().True(operationMsg.OK) // sending tokens to a module account should fail
-	suite.Require().Empty(operationMsg.Comment)
+	suite.Require().False(operationMsg.OK) // sending tokens to a module account should fail
+	suite.Require().Equal(operationMsg.Comment, "invalid transfers")
 	suite.Require().Equal(types.TypeMsgMultiSend, msg.Type())
 	suite.Require().Equal(types.ModuleName, msg.Route())
 	suite.Require().Len(futureOperations, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes: #751


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
