### PR TITLE
feat: change to create `chCheckTx` with the value set in app config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (config) [\#665](https://github.com/line/lbm-sdk/pull/665) remove bech32-cache-size
 * (x/foundation) [\#709](https://github.com/line/lbm-sdk/pull/709) add `gov mint` for x/foundation proposal
 * (iavl) [\#738](https://github.com/line/lbm-sdk/pull/738) bump github.com/cosmos/iavl from v0.17.3 to v0.19.3
+* (baseapp) [\#756](https://github.com/line/lbm-sdk/pull/756) Change to create chCheckTx with the value set in app config
 
 ### Improvements
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -16,6 +16,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/line/lbm-sdk/codec/types"
+	"github.com/line/lbm-sdk/server/config"
 	"github.com/line/lbm-sdk/snapshots"
 	"github.com/line/lbm-sdk/store"
 	"github.com/line/lbm-sdk/store/rootmulti"
@@ -75,6 +76,7 @@ type BaseApp struct { // nolint: maligned
 
 	checkAccountWGs *AccountWGs
 	chCheckTx       chan *RequestCheckTxAsync
+	chCheckTxSize   uint // chCheckTxSize is the initial size for chCheckTx
 
 	// an inter-block write-through cache provided to the context during deliverState
 	interBlockCache sdk.MultiStorePersistentCache
@@ -153,12 +155,17 @@ func NewBaseApp(
 		txDecoder:        txDecoder,
 		fauxMerkleMode:   false,
 		checkAccountWGs:  NewAccountWGs(),
-		chCheckTx:        make(chan *RequestCheckTxAsync, 10000), // TODO config channel buffer size. It might be good to set it tendermint mempool.size
 	}
 
 	for _, option := range options {
 		option(app)
 	}
+
+	chCheckTxSize := app.chCheckTxSize
+	if chCheckTxSize == 0 {
+		chCheckTxSize = config.DefaultChanCheckTxSize
+	}
+	app.chCheckTx = make(chan *RequestCheckTxAsync, chCheckTxSize)
 
 	if app.interBlockCache != nil {
 		app.cms.SetInterBlockCache(app.interBlockCache)

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/line/lbm-sdk/codec"
 	"github.com/line/lbm-sdk/codec/legacy"
+	"github.com/line/lbm-sdk/server/config"
 	"github.com/line/lbm-sdk/snapshots"
 	snapshottypes "github.com/line/lbm-sdk/snapshots/types"
 	"github.com/line/lbm-sdk/store/rootmulti"
@@ -541,6 +542,9 @@ func TestBaseAppOptionSeal(t *testing.T) {
 	})
 	require.Panics(t, func() {
 		app.SetRouter(NewRouter())
+	})
+	require.Panics(t, func() {
+		app.SetChanCheckTxSize(10)
 	})
 }
 
@@ -2068,4 +2072,17 @@ func TestSnapshotManager(t *testing.T) {
 	}
 	app.SetSnapshotStore(snapshotStore)
 	require.NotNil(t, app.SnapshotManager())
+}
+
+func TestSetChanCheckTxSize(t *testing.T) {
+	logger := defaultLogger()
+	db := dbm.NewMemDB()
+
+	var size = uint(100)
+
+	app := NewBaseApp(t.Name(), logger, db, nil, SetChanCheckTxSize(size))
+	require.Equal(t, int(size), cap(app.chCheckTx))
+
+	app = NewBaseApp(t.Name(), logger, db, nil)
+	require.Equal(t, config.DefaultChanCheckTxSize, cap(app.chCheckTx))
 }

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -6,11 +6,10 @@ import (
 
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/line/lbm-sdk/store/cache"
-
 	"github.com/line/lbm-sdk/codec/types"
 	"github.com/line/lbm-sdk/snapshots"
 	"github.com/line/lbm-sdk/store"
+	"github.com/line/lbm-sdk/store/cache"
 	sdk "github.com/line/lbm-sdk/types"
 )
 
@@ -88,6 +87,10 @@ func SetSnapshotKeepRecent(keepRecent uint32) func(*BaseApp) {
 // SetSnapshotStore sets the snapshot store.
 func SetSnapshotStore(snapshotStore *snapshots.Store) func(*BaseApp) {
 	return func(app *BaseApp) { app.SetSnapshotStore(snapshotStore) }
+}
+
+func SetChanCheckTxSize(size uint) func(*BaseApp) {
+	return func(app *BaseApp) { app.SetChanCheckTxSize(size) }
 }
 
 func (app *BaseApp) SetName(name string) {
@@ -248,6 +251,13 @@ func (app *BaseApp) SetInterfaceRegistry(registry types.InterfaceRegistry) {
 	app.interfaceRegistry = registry
 	app.grpcQueryRouter.SetInterfaceRegistry(registry)
 	app.msgServiceRouter.SetInterfaceRegistry(registry)
+}
+
+func (app *BaseApp) SetChanCheckTxSize(chanCheckTxSize uint) {
+	if app.sealed {
+		panic("SetChanCheckTxSize() on sealed BaseApp")
+	}
+	app.chCheckTxSize = chanCheckTxSize
 }
 
 func MetricsProvider(prometheus bool) cache.MetricsProvider {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -23,6 +23,9 @@ const (
 
 	// DefaultGRPCWebAddress defines the default address to bind the gRPC-web server to.
 	DefaultGRPCWebAddress = "0.0.0.0:9091"
+
+	// DefaultChanCheckTxSize defines the default maximum size of channel check tx in Baseapp
+	DefaultChanCheckTxSize = 10000
 )
 
 // BaseConfig defines the server's basic configuration
@@ -85,6 +88,9 @@ type BaseConfig struct {
 	// When true, Prometheus metrics are served under /metrics on prometheus_listen_addr in config.toml.
 	// It works when tendermint's prometheus option (config.toml) is set to true.
 	Prometheus bool `mapstructure:"prometheus"`
+
+	// ChanCheckTxSize is the size of RequestCheckTxAsync of BaseApp
+	ChanCheckTxSize uint `mapstructure:"chan-check-tx-size"`
 }
 
 // APIConfig defines the API listener configuration.
@@ -231,6 +237,7 @@ func DefaultConfig() *Config {
 			PruningInterval:     "0",
 			MinRetainBlocks:     0,
 			IndexEvents:         make([]string, 0),
+			ChanCheckTxSize:     DefaultChanCheckTxSize,
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -294,6 +301,7 @@ func GetConfig(v *viper.Viper) Config {
 			MinRetainBlocks:     v.GetUint64("min-retain-blocks"),
 			IAVLDisableFastNode: v.GetBool("iavl-disable-fastnode"),
 			IAVLCacheSize:       v.GetUint64("iavl-cache-size"),
+			ChanCheckTxSize:     v.GetUint("chan-check-tx-size"),
 		},
 		Telemetry: telemetry.Config{
 			ServiceName:             v.GetString("telemetry.service-name"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -24,7 +24,7 @@ const (
 	// DefaultGRPCWebAddress defines the default address to bind the gRPC-web server to.
 	DefaultGRPCWebAddress = "0.0.0.0:9091"
 
-	// DefaultChanCheckTxSize defines the default maximum size of channel check tx in Baseapp
+	// DefaultChanCheckTxSize defines the default size of channel check tx in Baseapp
 	DefaultChanCheckTxSize = 10000
 )
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -86,6 +86,10 @@ index-events = {{ .BaseConfig.IndexEvents }}
 # It works when tendermint's prometheus option (config.toml) is set to true.
 prometheus = {{ .BaseConfig.Prometheus }}
 
+# ChanCheckTxSize is he size of RequestCheckTxAsync of BaseApp
+# ChanCheckTxSize should be equals to or greater than the mempool size.
+chan-check-tx-size = {{ .BaseConfig.ChanCheckTxSize }}
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -86,8 +86,8 @@ index-events = {{ .BaseConfig.IndexEvents }}
 # It works when tendermint's prometheus option (config.toml) is set to true.
 prometheus = {{ .BaseConfig.Prometheus }}
 
-# ChanCheckTxSize is he size of RequestCheckTxAsync of BaseApp
-# ChanCheckTxSize should be equals to or greater than the mempool size.
+# ChanCheckTxSize is the size of RequestCheckTxAsync of BaseApp.
+# ChanCheckTxSize should be equals to or greater than the mempool size set in config.toml of Ostracon.
 chan-check-tx-size = {{ .BaseConfig.ChanCheckTxSize }}
 
 ###############################################################################

--- a/server/start.go
+++ b/server/start.go
@@ -176,7 +176,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 
 	cmd.Flags().Bool(FlagPrometheus, false, "Enable prometheus metric for app")
 
-	cmd.Flags().Uint(FlagChanCheckTxSize, config.DefaultChanCheckTxSize, "The maximum size of the chan-check-tx-size")
+	cmd.Flags().Uint(FlagChanCheckTxSize, config.DefaultChanCheckTxSize, "The size of the channel check tx")
 
 	// add support for all Ostracon-specific command line options
 	ostcmd.AddNodeFlags(cmd)

--- a/server/start.go
+++ b/server/start.go
@@ -52,6 +52,7 @@ const (
 	FlagTrace               = "trace"
 	FlagInvCheckPeriod      = "inv-check-period"
 	FlagPrometheus          = "prometheus"
+	FlagChanCheckTxSize     = "chan-check-tx-size"
 
 	FlagPruning           = "pruning"
 	FlagPruningKeepRecent = "pruning-keep-recent"
@@ -174,6 +175,8 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
 	cmd.Flags().Bool(FlagPrometheus, false, "Enable prometheus metric for app")
+
+	cmd.Flags().Uint(FlagChanCheckTxSize, config.DefaultChanCheckTxSize, "The maximum size of the chan-check-tx-size")
 
 	// add support for all Ostracon-specific command line options
 	ostcmd.AddNodeFlags(cmd)

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -287,6 +287,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetChanCheckTxSize(cast.ToUint(appOpts.Get(server.FlagChanCheckTxSize))),
 	)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change to create `chCheckTx` with the value set in app config.

Basically, `chCheckTx` of BaseApp should be equals to or greater than mempool size. 
But when running NewBaseApp, the mempool size can not know.
So I add the feature set the size of `chCheckTx` as config

So following features have been changed
* add `chCheckTxSize` in Baseapp
* add `FlagChanCheckTxSize` flag as cmd flag
* add `chan-check-tx-size` field in app config.
* set default `chanCheckTxSize` to 10000.

closes: #753 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
