### PR TITLE
fix: restore build norace flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client) [\#737](https://github.com/line/lbm-sdk/pull/737) check multisig key list to prevent unexpected key deletion
 * (simapp) [\#752](https://github.com/line/lbm-sdk/pull/752) add x/distribution's module account into blockedAddr
 * (x/auth) [\#754](https://github.com/line/lbm-sdk/pull/754) Fix wrong sequences in `sign-batch`
+* (x/foundation) [\#761](https://github.com/line/lbm-sdk/pull/761) restore build norace flag
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/x/foundation/client/testutil/cli_test.go
+++ b/x/foundation/client/testutil/cli_test.go
@@ -1,3 +1,6 @@
+//go:build norace
+// +build norace
+
 package testutil
 
 import (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Restores the removeed `build norace` flag.
ref. #709 
<!--- Describe your changes in detail -->
closes: #762 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
