### PR TITLE
fix: start telemetry independently from the API server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client) [\#737](https://github.com/line/lbm-sdk/pull/737) check multisig key list to prevent unexpected key deletion
 * (simapp) [\#752](https://github.com/line/lbm-sdk/pull/752) add x/distribution's module account into blockedAddr
 * (x/auth) [\#754](https://github.com/line/lbm-sdk/pull/754) Fix wrong sequences in `sign-batch`
+* (server) [\#763](https://github.com/line/lbm-sdk/pull/763) start telemetry independently from the API server
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -90,16 +90,6 @@ func New(clientCtx client.Context, logger log.Logger) *Server {
 // non-blocking, so an external signal handler must be used.
 func (s *Server) Start(cfg config.Config) error {
 	s.mtx.Lock()
-	if cfg.Telemetry.Enabled {
-		m, err := telemetry.New(cfg.Telemetry)
-		if err != nil {
-			s.mtx.Unlock()
-			return err
-		}
-
-		s.metrics = m
-		s.registerMetrics()
-	}
 
 	ostCfg := ostrpcserver.DefaultConfig()
 	ostCfg.MaxOpenConnections = int(cfg.API.MaxOpenConnections)
@@ -115,18 +105,17 @@ func (s *Server) Start(cfg config.Config) error {
 	}
 
 	s.registerGRPCGatewayRoutes()
-
 	s.listener = listener
 	var h http.Handler = s.Router
 
+	s.mtx.Unlock()
+
 	if cfg.API.EnableUnsafeCORS {
 		allowAllCORS := handlers.CORS(handlers.AllowedHeaders([]string{"Content-Type"}))
-		s.mtx.Unlock()
 		return ostrpcserver.Serve(s.listener, allowAllCORS(h), s.logger, ostCfg)
 	}
 
 	s.logger.Info("starting API server...")
-	s.mtx.Unlock()
 	return ostrpcserver.Serve(s.listener, s.Router, s.logger, ostCfg)
 }
 
@@ -139,6 +128,13 @@ func (s *Server) Close() error {
 
 func (s *Server) registerGRPCGatewayRoutes() {
 	s.Router.PathPrefix("/").Handler(s.GRPCGatewayRouter)
+}
+
+func (s *Server) SetTelemetry(m *telemetry.Metrics) {
+	s.mtx.Lock()
+	s.metrics = m
+	s.registerMetrics()
+	s.mtx.Unlock()
 }
 
 func (s *Server) registerMetrics() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #759 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
