### PR TITLE
docs: fix submit-proposal tx command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,3 +153,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (docs) [\#602](https://github.com/line/lbm-sdk/pull/602) update outdated events in specs
 * (docs) [\#721](https://github.com/line/lbm-sdk/pull/721) update x/foundation specification
 * (docs) [\#748](https://github.com/line/lbm-sdk/pull/748) add `GovMint` to x/foundation specification
+* (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation

--- a/x/foundation/README.md
+++ b/x/foundation/README.md
@@ -1049,7 +1049,7 @@ simd tx foundation update-decision-policy link1... \
 The `submit-proposal` command allows users to submit a new proposal.
 
 ```bash
-simd tx foundation submit-proposal [metadata] [proposers-json] [proposers-json] [messages-json] [flags]
+simd tx foundation submit-proposal [metadata] [proposers-json] [messages-json] [flags]
 ```
 
 Example:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a duplicate `[proposers-json]' in the command description of submit-proposal, so it was removed.
<!--- Describe your changes in detail -->
closes: #XXXX

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
