### PR TITLE
fix: export x/foundation pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth) [\#754](https://github.com/line/lbm-sdk/pull/754) Fix wrong sequences in `sign-batch`
 * (x/foundation) [\#761](https://github.com/line/lbm-sdk/pull/761) restore build norace flag
 * (server) [\#763](https://github.com/line/lbm-sdk/pull/763) start telemetry independently from the API server
+* (x/foundation) [\#772](https://github.com/line/lbm-sdk/pull/772) export x/foundation pool
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/x/foundation/keeper/genesis.go
+++ b/x/foundation/keeper/genesis.go
@@ -66,6 +66,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *foundation.GenesisState {
 		Proposals:          proposals,
 		Votes:              votes,
 		Authorizations:     k.GetGrants(ctx),
+		Pool:               k.GetPool(ctx),
 		GovMintLeftCount:   k.GetGovMintLeftCount(ctx),
 	}
 }

--- a/x/foundation/keeper/genesis_test.go
+++ b/x/foundation/keeper/genesis_test.go
@@ -170,6 +170,23 @@ func TestImportExportGenesis(t *testing.T) {
 				},
 			},
 		},
+		"pool": {
+			init: &foundation.GenesisState{
+				Params:     foundation.DefaultParams(),
+				Foundation: foundation.DefaultFoundation(),
+				Pool: foundation.Pool{
+					Treasury: sdk.NewDecCoins(sdk.NewDecCoin(sdk.DefaultBondDenom, sdk.OneInt())),
+				},
+			},
+			valid: true,
+			export: &foundation.GenesisState{
+				Params:     foundation.DefaultParams(),
+				Foundation: foundation.DefaultFoundation(),
+				Pool: foundation.Pool{
+					Treasury: sdk.NewDecCoins(sdk.NewDecCoin(sdk.DefaultBondDenom, sdk.OneInt())),
+				},
+			},
+		},
 		"member of long metadata": {
 			init: &foundation.GenesisState{
 				Params: foundation.DefaultParams(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch will add a logic to export the x/foundation's pool.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
