### PR TITLE
fix: guide users to use generate only in messages for x/foundation authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 ### Breaking Changes
+* (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
 
 ### Build, CI
 

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -21,6 +21,17 @@ const (
 	ExecTry  = "try"
 )
 
+func validateGenerateOnly(cmd *cobra.Command) error {
+	generateOnly, err := cmd.Flags().GetBool(flags.FlagGenerateOnly)
+	if err != nil {
+		return err
+	}
+	if !generateOnly {
+		return fmt.Errorf("you must use it with the flag --%s", flags.FlagGenerateOnly)
+	}
+	return nil
+}
+
 func parseParams(codec codec.Codec, paramsJSON string) (*foundation.Params, error) {
 	var params foundation.Params
 	if err := codec.UnmarshalJSON([]byte(paramsJSON), &params); err != nil {
@@ -164,8 +175,7 @@ Example of the content of params-json:
 }
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -180,7 +190,7 @@ Example of the content of params-json:
 			}
 
 			msg := foundation.MsgUpdateParams{
-				Authority: authority,
+				Authority: args[0],
 				Params:    *params,
 			}
 			if err := msg.ValidateBasic(); err != nil {
@@ -191,6 +201,7 @@ Example of the content of params-json:
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+
 	return cmd
 }
 
@@ -240,8 +251,7 @@ func NewTxCmdWithdrawFromTreasury() *cobra.Command {
 		Long: `Withdraw coins from the treasury
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -256,7 +266,7 @@ func NewTxCmdWithdrawFromTreasury() *cobra.Command {
 			}
 
 			msg := foundation.MsgWithdrawFromTreasury{
-				Authority: authority,
+				Authority: args[0],
 				To:        args[1],
 				Amount:    amount,
 			}
@@ -296,8 +306,7 @@ Example of the content of members-json:
 Set a member's participating to false to delete it.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -312,7 +321,7 @@ Set a member's participating to false to delete it.
 			}
 
 			msg := foundation.MsgUpdateMembers{
-				Authority:     authority,
+				Authority:     args[0],
 				MemberUpdates: updates,
 			}
 			if err := msg.ValidateBasic(); err != nil {
@@ -345,8 +354,7 @@ Example of the content of policy-json:
 }
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -356,7 +364,7 @@ Example of the content of policy-json:
 			}
 
 			msg := foundation.MsgUpdateDecisionPolicy{
-				Authority: authority,
+				Authority: args[0],
 			}
 			policy, err := parseDecisionPolicy(clientCtx.Codec, args[1])
 			if err != nil {
@@ -646,8 +654,7 @@ Example of the content of authorization-json:
 }
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -657,7 +664,7 @@ Example of the content of authorization-json:
 			}
 
 			msg := foundation.MsgGrant{
-				Authority: authority,
+				Authority: args[0],
 				Grantee:   args[1],
 			}
 			authorization, err := parseAuthorization(clientCtx.Codec, args[2])
@@ -687,8 +694,7 @@ func NewTxCmdRevoke() *cobra.Command {
 		Long: `Revoke an authorization of grantee
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -698,7 +704,7 @@ func NewTxCmdRevoke() *cobra.Command {
 			}
 
 			msg := foundation.MsgRevoke{
-				Authority:  authority,
+				Authority:  args[0],
 				Grantee:    args[1],
 				MsgTypeUrl: args[2],
 			}
@@ -721,8 +727,7 @@ func NewTxCmdGovMint() *cobra.Command {
 		Long: `mint coins for foundation
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authority := args[0]
-			if err := cmd.Flags().Set(flags.FlagFrom, authority); err != nil {
+			if err := validateGenerateOnly(cmd); err != nil {
 				return err
 			}
 
@@ -737,7 +742,7 @@ func NewTxCmdGovMint() *cobra.Command {
 			}
 
 			msg := foundation.MsgGovMint{
-				Authority: authority,
+				Authority: args[0],
 				Amount:    amount,
 			}
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -201,7 +201,6 @@ Example of the content of params-json:
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
-
 	return cmd
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch will guide users to use the generate-only flag in following commands:
- MsgUpdateParams
- MsgWithdrawFromTreasury
- MsgUpdateMembers
- MsgUpdateDecisionPolicy
- MsgGrant
- MsgRevoke
- MsgGovMint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
