### PR TITLE
fix: remove mock from genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth) [\#754](https://github.com/line/lbm-sdk/pull/754) Fix wrong sequences in `sign-batch`
 * (x/foundation) [\#761](https://github.com/line/lbm-sdk/pull/761) restore build norace flag
 * (server) [\#763](https://github.com/line/lbm-sdk/pull/763) start telemetry independently from the API server
+* (app) [\#774](https://github.com/line/lbm-sdk/pull/774) remove `ibcmock` from app initializer
 
 ### Breaking Changes
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -534,7 +534,6 @@ func NewSimApp(
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		transferModule,
 		icaModule,
-		mockModule,
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -563,7 +562,6 @@ func NewSimApp(
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
 		icatypes.ModuleName,
-		ibcmock.ModuleName,
 		token.ModuleName,
 		collection.ModuleName,
 		wasm.ModuleName,
@@ -588,7 +586,6 @@ func NewSimApp(
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,
 		icatypes.ModuleName,
-		ibcmock.ModuleName,
 		foundation.ModuleName,
 		token.ModuleName,
 		collection.ModuleName,
@@ -617,7 +614,6 @@ func NewSimApp(
 		authz.ModuleName,
 		ibctransfertypes.ModuleName,
 		icatypes.ModuleName,
-		ibcmock.ModuleName,
 		feegrant.ModuleName,
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In #651, the `ibcmock module` was included in the module manager initialization and begin blocker, end blocker, genesis ordering. 
So, there was a bug in genesis.json being included in the mock. 
I removed the mock here.
<!--- Describe your changes in detail -->
closes: #770 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
