### PR TITLE
ci: change github action trigger rules for `release/*` and `rc*/*` branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - rc*/*
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+      - rc*/*
+      - release/*
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -3,6 +3,11 @@ name: Release Sims
 # This workflow only runs on a pull request added `release` label
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
     branches:
       - main
       - rc*/*

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -2,10 +2,8 @@ name: Release Sims
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
 # This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
 on:
-  push:
-    tags:
-      - "release"
-      - "release to main"
+  pull_request:
+    types: [ labeled ]
 
 jobs:
   cleanup-runs:
@@ -14,11 +12,11 @@ jobs:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' && github.event.label.name == 'release'"
 
   build:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'skip-sims')"
+    if: "!contains(github.event.head_commit.message, 'skip-sims')  && github.event.label.name == 'release'"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.3.0

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -2,7 +2,6 @@ name: Release Sims
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
 # This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
 on:
-  pull_request:
   push:
     tags:
       - "release"

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -3,7 +3,7 @@ name: Release Sims
 # This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, unlabeled ]
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -3,7 +3,7 @@ name: Release Sims
 # This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
 on:
   pull_request:
-    types: [ labeled, unlabeled ]
+    types: [ labeled ]
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -2,7 +2,11 @@ name: Release Sims
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
 # This workflow only runs on a pull request added `release` label
 on:
-  pull_request
+  pull_request:
+    branches:
+      - main
+      - rc*/*
+      - release/*
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -1,9 +1,8 @@
 name: Release Sims
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
-# This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
+# This workflow only runs on a pull request added `release` label
 on:
-  pull_request:
-    types: [ labeled ]
+  pull_request
 
 jobs:
   cleanup-runs:
@@ -12,11 +11,11 @@ jobs:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' && github.event.label.name == 'release'"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' && contains(github.event.pull_request.labels.*.name, 'release')"
 
   build:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'skip-sims')  && github.event.label.name == 'release'"
+    if: "!contains(github.event.head_commit.message, 'skip-sims') && contains(github.event.pull_request.labels.*.name, 'release')"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.3.0

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -3,9 +3,10 @@ name: Release Sims
 # This workflow only runs on a pull request when the branch contains rc** (rc1/vX.X.x)
 on:
   pull_request:
-    branches:
-      - "rc**"
-      - "release/*"
+  push:
+    tags:
+      - "release"
+      - "release to main"
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - rc*/*
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+      - rc*/*
+      - release/*
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
 
 ### Build, CI
-* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change the `release-sims` test trigger rule
+* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change github action trigger rules for `release/*` and `rc*/*` branches
 
 ### Document Updates
 * (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
 
 ### Build, CI
+* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change the `release-sims` test trigger rule
 
 ### Document Updates
 * (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closed: #771 

* Change the `release-sims` test trigger rule when add `release` tag.
* Add github action in `rc*/*` and `release/*` branches like `main` branch

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `release-sims` test of ci take too many times, and there is alternative short test. So I think it is no need to test every PR.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
