### PR TITLE
fix: add unhandled return error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
 * (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
 
-
 ### Breaking Changes
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 * (x/foundation) [\#772](https://github.com/line/lbm-sdk/pull/772) export x/foundation pool
+* (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
 
 ### Breaking Changes
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -61,8 +61,7 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 		grpcCtx = context.WithValue(grpcCtx, sdk.SdkContextKey, sdkCtx)
 
 		md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
-		err = grpc.SetHeader(grpcCtx, md)
-		if err != nil {
+		if err = grpc.SetHeader(grpcCtx, md); err != nil {
 			return nil, err
 		}
 

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -61,7 +61,10 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 		grpcCtx = context.WithValue(grpcCtx, sdk.SdkContextKey, sdkCtx)
 
 		md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
-		grpc.SetHeader(grpcCtx, md)
+		err = grpc.SetHeader(grpcCtx, md)
+		if err != nil {
+			return nil, err
+		}
 
 		return handler(grpcCtx, req)
 	}

--- a/init_node.sh
+++ b/init_node.sh
@@ -44,8 +44,8 @@ if [ -n "$2" ]; then
 fi
 
 VALIDATOR_PREFIX="validator"
-COINS="100000000000stake,100000000000ukrw"
-DELEGATE="10000000000stake"
+COINS="10000000000toy"
+DELEGATE="10000000000toy"
 
 # Create base dir and gentxs dir
 if ! mkdir -p ${GENTXS_DIR} 2> /dev/null; then

--- a/init_node.sh
+++ b/init_node.sh
@@ -44,8 +44,8 @@ if [ -n "$2" ]; then
 fi
 
 VALIDATOR_PREFIX="validator"
-COINS="10000000000toy"
-DELEGATE="10000000000toy"
+COINS="100000000000stake,100000000000ukrw"
+DELEGATE="10000000000stake"
 
 # Create base dir and gentxs dir
 if ! mkdir -p ${GENTXS_DIR} 2> /dev/null; then

--- a/server/start.go
+++ b/server/start.go
@@ -112,9 +112,12 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 
 			// Bind flags to the Context's Viper so the app construction can set
 			// options accordingly.
-			serverCtx.Viper.BindPFlags(cmd.Flags())
+			err := serverCtx.Viper.BindPFlags(cmd.Flags())
+			if err != nil {
+				return err
+			}
 
-			_, err := GetPruningOptionsFromFlags(serverCtx.Viper)
+			_, err = GetPruningOptionsFromFlags(serverCtx.Viper)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/server/start.go
+++ b/server/start.go
@@ -112,12 +112,11 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 
 			// Bind flags to the Context's Viper so the app construction can set
 			// options accordingly.
-			err := serverCtx.Viper.BindPFlags(cmd.Flags())
-			if err != nil {
+			if err := serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
 
-			_, err = GetPruningOptionsFromFlags(serverCtx.Viper)
+			_, err := GetPruningOptionsFromFlags(serverCtx.Viper)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/server/util.go
+++ b/server/util.go
@@ -120,12 +120,10 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	basename := path.Base(executableName)
 
 	// Configure the viper instance
-	err = serverCtx.Viper.BindPFlags(cmd.Flags())
-	if err != nil {
+	if err = serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
 		return err
 	}
-	err = serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
-	if err != nil {
+	if err = serverCtx.Viper.BindPFlags(cmd.PersistentFlags()); err != nil {
 		return err
 	}
 	serverCtx.Viper.SetEnvPrefix(basename)

--- a/server/util.go
+++ b/server/util.go
@@ -120,8 +120,14 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	basename := path.Base(executableName)
 
 	// Configure the viper instance
-	serverCtx.Viper.BindPFlags(cmd.Flags())
-	serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
+	err = serverCtx.Viper.BindPFlags(cmd.Flags())
+	if err != nil {
+		return err
+	}
+	err = serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
+	if err != nil {
+		return err
+	}
 	serverCtx.Viper.SetEnvPrefix(basename)
 	serverCtx.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	serverCtx.Viper.AutomaticEnv()

--- a/x/auth/client/rest/query.go
+++ b/x/auth/client/rest/query.go
@@ -103,8 +103,7 @@ func QueryTxsRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 		}
 
 		for _, txRes := range searchResult.Txs {
-			err = packStdTxResponse(w, clientCtx, txRes)
-			if err != nil {
+			if err = packStdTxResponse(w, clientCtx, txRes); err != nil {
 				// Error is already returned by packStdTxResponse.
 				return
 			}

--- a/x/auth/client/rest/query.go
+++ b/x/auth/client/rest/query.go
@@ -103,7 +103,11 @@ func QueryTxsRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 		}
 
 		for _, txRes := range searchResult.Txs {
-			packStdTxResponse(w, clientCtx, txRes)
+			err = packStdTxResponse(w, clientCtx, txRes)
+			if err != nil {
+				// Error is already returned by packStdTxResponse.
+				return
+			}
 		}
 
 		err = checkAminoMarshalError(clientCtx, searchResult, "/cosmos/tx/v1beta1/txs")

--- a/x/bank/client/cli/tx.go
+++ b/x/bank/client/cli/tx.go
@@ -33,7 +33,10 @@ func NewSendTxCmd() *cobra.Command {
 ignored as it is implied from [from_key_or_address].`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Flags().Set(flags.FlagFrom, args[0])
+			err := cmd.Flags().Set(flags.FlagFrom, args[0])
+			if err != nil {
+				return err
+			}
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err

--- a/x/bank/client/cli/tx.go
+++ b/x/bank/client/cli/tx.go
@@ -33,8 +33,7 @@ func NewSendTxCmd() *cobra.Command {
 ignored as it is implied from [from_key_or_address].`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cmd.Flags().Set(flags.FlagFrom, args[0])
-			if err != nil {
+			if err := cmd.Flags().Set(flags.FlagFrom, args[0]); err != nil {
 				return err
 			}
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/x/feegrant/client/cli/tx.go
+++ b/x/feegrant/client/cli/tx.go
@@ -64,7 +64,10 @@ Examples:
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			cmd.Flags().Set(flags.FlagFrom, args[0])
+			err := cmd.Flags().Set(flags.FlagFrom, args[0])
+			if err != nil {
+				return err
+			}
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -195,7 +198,10 @@ Example:
 		),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Flags().Set(flags.FlagFrom, args[0])
+			err := cmd.Flags().Set(flags.FlagFrom, args[0])
+			if err != nil {
+				return err
+			}
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err

--- a/x/feegrant/client/cli/tx.go
+++ b/x/feegrant/client/cli/tx.go
@@ -64,8 +64,7 @@ Examples:
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := cmd.Flags().Set(flags.FlagFrom, args[0])
-			if err != nil {
+			if err := cmd.Flags().Set(flags.FlagFrom, args[0]); err != nil {
 				return err
 			}
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -198,8 +197,7 @@ Example:
 		),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cmd.Flags().Set(flags.FlagFrom, args[0])
-			if err != nil {
+			if err := cmd.Flags().Set(flags.FlagFrom, args[0]); err != nil {
 				return err
 			}
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/x/foundation/keeper/member.go
+++ b/x/foundation/keeper/member.go
@@ -16,8 +16,7 @@ func validateMetadata(metadata string, config foundation.Config) error {
 
 func (k Keeper) UpdateDecisionPolicy(ctx sdk.Context, policy foundation.DecisionPolicy) error {
 	info := k.GetFoundationInfo(ctx)
-	err := info.SetDecisionPolicy(policy)
-	if err != nil {
+	if err := info.SetDecisionPolicy(policy); err != nil {
 		return err
 	}
 	info.Version++

--- a/x/foundation/keeper/member.go
+++ b/x/foundation/keeper/member.go
@@ -16,7 +16,10 @@ func validateMetadata(metadata string, config foundation.Config) error {
 
 func (k Keeper) UpdateDecisionPolicy(ctx sdk.Context, policy foundation.DecisionPolicy) error {
 	info := k.GetFoundationInfo(ctx)
-	info.SetDecisionPolicy(policy)
+	err := info.SetDecisionPolicy(policy)
+	if err != nil {
+		return err
+	}
 	info.Version++
 	k.SetFoundationInfo(ctx, info)
 

--- a/x/slashing/genesis.go
+++ b/x/slashing/genesis.go
@@ -16,7 +16,10 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, stakingKeeper types.Stak
 			if err != nil {
 				panic(err)
 			}
-			keeper.AddPubkey(ctx, consPk)
+			err = keeper.AddPubkey(ctx, consPk)
+			if err != nil {
+				panic(err)
+			}
 			return false
 		},
 	)

--- a/x/slashing/genesis.go
+++ b/x/slashing/genesis.go
@@ -16,8 +16,7 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, stakingKeeper types.Stak
 			if err != nil {
 				panic(err)
 			}
-			err = keeper.AddPubkey(ctx, consPk)
-			if err != nil {
+			if err = keeper.AddPubkey(ctx, consPk); err != nil {
 				panic(err)
 			}
 			return false

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -32,7 +32,10 @@ func (k Keeper) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) e
 	if err != nil {
 		return err
 	}
-	k.AddPubkey(ctx, consPk)
+	err = k.AddPubkey(ctx, consPk)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -32,8 +32,7 @@ func (k Keeper) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) e
 	if err != nil {
 		return err
 	}
-	err = k.AddPubkey(ctx, consPk)
-	if err != nil {
+	if err = k.AddPubkey(ctx, consPk); err != nil {
 		return err
 	}
 

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -39,7 +39,10 @@ func InitGenesis(
 		keeper.SetValidator(ctx, validator)
 
 		// Manually set indices for the first time
-		keeper.SetValidatorByConsAddr(ctx, validator)
+		err := keeper.SetValidatorByConsAddr(ctx, validator)
+		if err != nil {
+			panic(err)
+		}
 		keeper.SetValidatorByPowerIndex(ctx, validator)
 
 		// Call the creation hook if not exported

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -39,8 +39,7 @@ func InitGenesis(
 		keeper.SetValidator(ctx, validator)
 
 		// Manually set indices for the first time
-		err := keeper.SetValidatorByConsAddr(ctx, validator)
-		if err != nil {
+		if err := keeper.SetValidatorByConsAddr(ctx, validator); err != nil {
 			panic(err)
 		}
 		keeper.SetValidatorByPowerIndex(ctx, validator)

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -92,8 +92,7 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 	validator.MinSelfDelegation = msg.MinSelfDelegation
 
 	k.SetValidator(ctx, validator)
-	err = k.SetValidatorByConsAddr(ctx, validator)
-	if err != nil {
+	if err = k.SetValidatorByConsAddr(ctx, validator); err != nil {
 		return nil, err
 	}
 	k.SetNewValidatorByPowerIndex(ctx, validator)

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -92,7 +92,10 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 	validator.MinSelfDelegation = msg.MinSelfDelegation
 
 	k.SetValidator(ctx, validator)
-	k.SetValidatorByConsAddr(ctx, validator)
+	err = k.SetValidatorByConsAddr(ctx, validator)
+	if err != nil {
+		return nil, err
+	}
 	k.SetNewValidatorByPowerIndex(ctx, validator)
 
 	// call the after-creation hook

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -538,8 +538,7 @@ func withPageKeyDecoded(flagSet *flag.FlagSet) *flag.FlagSet {
 	if err != nil {
 		panic(err.Error())
 	}
-	err = flagSet.Set(flags.FlagPageKey, string(raw))
-	if err != nil {
+	if err = flagSet.Set(flags.FlagPageKey, string(raw)); err != nil {
 		panic(err.Error())
 	}
 	return flagSet

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -538,7 +538,10 @@ func withPageKeyDecoded(flagSet *flag.FlagSet) *flag.FlagSet {
 	if err != nil {
 		panic(err.Error())
 	}
-	flagSet.Set(flags.FlagPageKey, string(raw))
+	err = flagSet.Set(flags.FlagPageKey, string(raw))
+	if err != nil {
+		panic(err.Error())
+	}
 	return flagSet
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
### Add unhandled return error handling.
* baseapp/grpcserver.go
  * grpc.SetHeader(grpcCtx, md)
* server/start.go
  * serverCtx.Viper.BindPFlags(cmd.Flags())
* server/util.go
  * serverCtx.Viper.BindPFlags(cmd.Flags())
  *  serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
* x/auth/client/rest/query.go
  *  packStdTxResponse(w, clientCtx, txRes)
* x/bank/client/cli/tx.go
  * cmd.Flags().Set(flags.FlagFrom, args[0])
* x/feegrant/client/cli/tx.go
  * cmd.Flags().Set(flags.FlagFrom, args[0])
* x/foundation/keeper/member.go
  *  info.SetDecisionPolicy(policy)
* x/slashing/genesis.go
  * keeper.AddPubkey(ctx, consPk)
* x/slashing/keeper/hooks.go
  * keeper.AddPubkey(ctx, consPk)
* x/staking/genesis.go
  * keeper.SetValidatorByConsAddr(ctx, validator)
* x/staking/keeper/msg_server.go
  * k.SetValidatorByConsAddr(ctx, validator)
* x/wasm/client/cli/query.go
  * flagSet.Set(flags.FlagPageKey, string(raw))


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
