### PR TITLE
fix: fix test flow to install libsodium

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,12 +135,18 @@ jobs:
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
         if: env.GIT_DIFF
+      - name: install libsodium
+        run: |
+          make libsodium
+        if: env.GIT_DIFF
       - name: test & coverage report creation
         env:
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
+          CGO_CFLAGS: -I/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/include
+          CGO_LDFLAGS: -L/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/lib -lsodium
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='norace ledger test_ledger_mock goleveldb libsodium'
+          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='norace ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:
@@ -217,13 +223,19 @@ jobs:
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
         if: env.GIT_DIFF
+      - name: install libsodium
+        run: |
+          make libsodium
+        if: env.GIT_DIFF
       - name: test & coverage report creation
         env:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
+          CGO_CFLAGS: -I/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/include
+          CGO_LDFLAGS: -L/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/lib -lsodium
         run: |
-          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb libsodium'
+          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,8 @@ jobs:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: -I${{ GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include
-          CGO_LDFLAGS: -L${{ GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium
+          CGO_CFLAGS: -I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include
+          CGO_LDFLAGS: -L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium
         run: |
           xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+            .github/workflows/test.yml
       - name: Build
         run: GOOS=linux CGO_ENABLED=1 GOARCH=${{ matrix.goarch }} CC=${{ matrix.gcc }} LEDGER_ENABLED=false make build
 
@@ -129,6 +130,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+            .github/workflows/test.yml
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
@@ -156,6 +158,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+            .github/workflows/test.yml
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-00-coverage"
@@ -209,6 +212,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+            .github/workflows/test.yml
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,8 @@ jobs:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: -I/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/include
-          CGO_LDFLAGS: -L/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/lib -lsodium
+          CGO_CFLAGS: -I${{ GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include
+          CGO_LDFLAGS: -L${{ GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium
         run: |
           xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
         env:
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: "-I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium"
+          CGO_CFLAGS: "-I${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='norace ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF
@@ -232,8 +232,8 @@ jobs:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: "-I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium"
+          CGO_CFLAGS: "-I${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
         env:
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: -I/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/include
-          CGO_LDFLAGS: -L/home/runner/work/lbm-sdk/lbm-sdk/tools/sodium/linux_amd64/lib -lsodium
+          CGO_CFLAGS: "-I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='norace ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF
@@ -232,8 +232,8 @@ jobs:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: -I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include
-          CGO_LDFLAGS: -L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium
+          CGO_CFLAGS: "-I${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${{ env.GITHUB_WORKSPACE }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
         env:
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: "-I${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/lib -lsodium"
+          CGO_CFLAGS: "-I${{ github.workspace }}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${{ github.workspace }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='norace ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF
@@ -232,8 +232,8 @@ jobs:
           USE_PREFETCH: NO
           USE_PRELOAD: 1,4
           SAVE_BRANCH_LAUNCH_DEPTH: 1
-          CGO_CFLAGS: "-I${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${GITHUB_WORKSPACE}/tools/sodium/linux_amd64/lib -lsodium"
+          CGO_CFLAGS: "-I${{ github.workspace }}/tools/sodium/linux_amd64/include"
+          CGO_LDFLAGS: "-L${{ github.workspace }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
           xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -timeout 30m -race -tags='cgo ledger test_ledger_mock goleveldb gcc libsodium'
         if: env.GIT_DIFF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
 * (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
 * (x/collection,x/token) [\#798](https://github.com/line/lbm-sdk/pull/798) Fix x/collection ModifyContract
+* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodiums
 
 ### Breaking Changes
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
 * (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
 * (x/collection,x/token) [\#798](https://github.com/line/lbm-sdk/pull/798) Fix x/collection ModifyContract
-* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodiums
+* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodium
 
 ### Breaking Changes
 * (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR has following changes.
- add test.yml to diff target in test.yml
- add step to install libsodium

related: #801

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even if ci test is changed, the test is skipped. I missed that it had to install libsodium because of that.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
