### PR TITLE
Release lbm-sdk v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [Unreleased](https://github.com/line/lbm-sdk/compare/v0.46.0-rc10...HEAD)
+## [Unreleased](https://github.com/line/lbm-sdk/compare/v0.46.0...HEAD)
 
 ### Features
 
 ### Improvements
-* (ostracon) [\#811](https://github.com/line/lbm-sdk/pull/811) bump up Ostracon from `2231684789c6e754744e3f10f8b41c96c4575ad1` to v1.0.7
 
 ### Bug Fixes
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,39 +1,12 @@
 # Changelog
 
-## [v0.45.0-rc10](https://github.com/line/lbm-sdk/releases/tag/v0.45.0-rc10)
+## [v0.46.0](https://github.com/line/lbm-sdk/releases/tag/v0.46.0) - 2022-11-28
 
-This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
+This version based on cosmos-sdk v0.45.10, wasmd v0.27.0 and Ostracon v1.0.7.
 
 ### Features
 * (global) [\#783](https://github.com/line/lbm-sdk/pull/783) bump up github.com/cosmos/cosmos-sdk to v0.45.10
 * (build) [\#793](https://github.com/line/lbm-sdk/pull/793) enable to use libsodium version ostracon
-
-### Improvements
-* (x/auth) [\#776](https://github.com/line/lbm-sdk/pull/776) remove unused MsgEmpty
-
-### Bug Fixes
-* (x/foundation) [\#772](https://github.com/line/lbm-sdk/pull/772) export x/foundation pool
-* (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
-* (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
-* (x/collection,x/token) [\#798](https://github.com/line/lbm-sdk/pull/798) Fix x/collection ModifyContract
-* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodium
-* (x/collection,token) [\#784](https://github.com/line/lbm-sdk/pull/784) Make field key matching in x/token & x/collection case-sensitive
-
-### Breaking Changes
-* (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
-* (x/foundation) [\#790](https://github.com/line/lbm-sdk/pull/790) fix case of gov_mint_left_count in x/foundation
-
-### Build, CI
-* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change github action trigger rules for `release/*` and `rc*/*` branches
-
-### Document Updates
-* (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation
-* (docs) [\#802](https://github.com/line/lbm-sdk/pull/802) update x/foundation documentation
-
-
-## [v0.45.0-rc9](https://github.com/line/lbm-sdk/releases/tag/v0.45.0-rc9)
-
-### Features
 * (x/wasm) [\#570](https://github.com/line/lbm-sdk/pull/570) Merge wasmd 0.27.0
 * (x/wasm) [\#470](https://github.com/line/lbm-sdk/pull/470) remove contract activation control by actor
 * (x/wasm) [\#513](https://github.com/line/lbm-sdk/pull/513) fix message representation for signing
@@ -57,6 +30,8 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (x/foundation) [\#758](https://github.com/line/lbm-sdk/pull/758) add invariants to x/foundation
 
 ### Improvements
+* (ostracon) [\#811](https://github.com/line/lbm-sdk/pull/811) bump up Ostracon from `2231684789c6e754744e3f10f8b41c96c4575ad1` to v1.0.7
+* (x/auth) [\#776](https://github.com/line/lbm-sdk/pull/776) remove unused MsgEmpty
 * (refactor) [\#493](https://github.com/line/lbm-sdk/pull/493) restructure x/consortium
 * (server/grpc) [\#526](https://github.com/line/lbm-sdk/pull/526) add index field into TxResponse
 * (cli) [\#535](https://github.com/line/lbm-sdk/pull/536) updated ostracon to v1.0.5; `unsafe-reset-all` command has been moved to the `ostracon` sub-command.
@@ -90,6 +65,12 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (x/foundation) [\#757](https://github.com/line/lbm-sdk/pull/757) remove redundant granter from x/foundation events
 
 ### Bug Fixes
+* (x/foundation) [\#772](https://github.com/line/lbm-sdk/pull/772) export x/foundation pool
+* (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
+* (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
+* (x/collection,x/token) [\#798](https://github.com/line/lbm-sdk/pull/798) Fix x/collection ModifyContract
+* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodium
+* (x/collection,token) [\#784](https://github.com/line/lbm-sdk/pull/784) Make field key matching in x/token & x/collection case-sensitive
 * (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path
 * (client) [\#476](https://github.com/line/lbm-sdk/pull/476) change the default value of the client output format in the config
 * (server/grpc) [\#516](https://github.com/line/lbm-sdk/pull/516) restore build norace flag
@@ -124,6 +105,8 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (server) [\#763](https://github.com/line/lbm-sdk/pull/763) start telemetry independently from the API server
 
 ### Breaking Changes
+* (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
+* (x/foundation) [\#790](https://github.com/line/lbm-sdk/pull/790) fix case of gov_mint_left_count in x/foundation
 * (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path
 * (global) [\#603](https://github.com/line/lbm-sdk/pull/603) apply types/address.go from cosmos-sdk@v0.45.1
 * (amino) [\#600](https://github.com/line/lbm-sdk/pull/600) change amino codec path from `lbm-sdk/` to `cosmos-sdk/`
@@ -133,6 +116,7 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (proto) [\#627](https://github.com/line/lbm-sdk/pull/627) revert changes in x/slashing proto
 
 ### Build, CI
+* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change github action trigger rules for `release/*` and `rc*/*` branches
 * (ci) [\#457](https://github.com/line/lbm-sdk/pull/457), [\#471](https://github.com/line/lbm-sdk/pull/471) add swagger check
 * (ci) [\#469](https://github.com/line/lbm-sdk/pull/469) publish docker image on tag push
 * (ci) [\#580](https://github.com/line/lbm-sdk/pull/580) fix the problem that the registered docker image couldn't run on M1.
@@ -141,6 +125,8 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (ci) [\#619](https://github.com/line/lbm-sdk/pull/619) change the Dockerfile to use the downloaded static library
 
 ### Document Updates
+* (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation
+* (docs) [\#802](https://github.com/line/lbm-sdk/pull/802) update x/foundation documentation
 * (docs) [\#483](https://github.com/line/lbm-sdk/pull/483) update documents on x/stakingplus
 * (docs) [\#490](https://github.com/line/lbm-sdk/pull/490) update documents on x/consortium
 * (docs) [\#602](https://github.com/line/lbm-sdk/pull/602) update outdated events in specs
@@ -148,7 +134,7 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (docs) [\#748](https://github.com/line/lbm-sdk/pull/748) add `GovMint` to x/foundation specification
 
 
-## [v0.45.0-rc0](https://github.com/line/lbm-sdk/releases/tag/v0.45.0-rc0)
+## [v0.45.0](https://github.com/line/lbm-sdk/releases/tag/v0.45.0)
 
 ### Features
 * (x/wasm) [\#444](https://github.com/line/lbm-sdk/pull/444) Merge wasmd 0.19.0
@@ -159,6 +145,7 @@ This version based on cosmos-sdk v0.45.10 and Ostracon v1.0.7.
 * (x/token) [\#416](https://github.com/line/lbm-sdk/pull/416) Migrate token module from line/link
 
 ### Bug Fixes
+* (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path
 * (x/wasm) [\#436](https://github.com/line/lbm-sdk/pull/436) remove `x/wasm/linkwasmd`
 
 ### Build, CI


### PR DESCRIPTION
## Release v0.46.0 - 2022-11-28

This version based on cosmos-sdk v0.45.10, wasmd v0.27.0 and Ostracon v1.0.7.

### Features
* (global) [\#783](https://github.com/line/lbm-sdk/pull/783) bump up github.com/cosmos/cosmos-sdk to v0.45.10
* (build) [\#793](https://github.com/line/lbm-sdk/pull/793) enable to use libsodium version ostracon
* (x/wasm) [\#570](https://github.com/line/lbm-sdk/pull/570) Merge wasmd 0.27.0
* (x/wasm) [\#470](https://github.com/line/lbm-sdk/pull/470) remove contract activation control by actor
* (x/wasm) [\#513](https://github.com/line/lbm-sdk/pull/513) fix message representation for signing
* (x/foundation) [\#518](https://github.com/line/lbm-sdk/pull/518) add foundation treasury feature to x/foundation
* (x/foundation) [\#528](https://github.com/line/lbm-sdk/pull/528) add a feature of whitelist for /lbm.foundation.v1.MsgWithdrawFromTreasury
* (proto) [\#584](https://github.com/line/lbm-sdk/pull/564) remove `prove` field in the `GetTxsEventRequest` of `tx` proto
* (x/collection) [\#571](https://github.com/line/lbm-sdk/pull/571) add x/collection proto
* (x/collection) [\#574](https://github.com/line/lbm-sdk/pull/574) implement x/collection
* (store) [\#605](https://github.com/line/lbm-sdk/pull/605) replace line/iavl and line/tm-db with cosmos/iavl and tendermint/tm-db.
* (server/grpc) [\#607](https://github.com/line/lbm-sdk/pull/607) revert gRPC block height header.
* (global) [\#611](https://github.com/line/lbm-sdk/pull/611) bump github.com/cosmos/cosmos-sdk from v0.45.1 to v0.45.6
* (simapp) [\#620](https://github.com/line/lbm-sdk/pull/620) chore: add iterator feature for simapp
* (x/collection) [\#622](https://github.com/line/lbm-sdk/pull/622) add Query/TokenClassTypeName
* (x/bank) [\#629](https://github.com/line/lbm-sdk/pull/629) remove unsafe balance changing methods from bank keeper such as `SetBalance` and `SetSupply`.
* (x/wasm) [\#649](https://github.com/line/lbm-sdk/pull/649) fix: wasm module's FIXME in the snapshotter.go file
* (x/ibc) [\#651](https://github.com/line/lbm-sdk/pull/651) feat: update x/ibc to support github.com/cosmos/ibc-go@v3.0.0
* (config) [\#665](https://github.com/line/lbm-sdk/pull/665) remove bech32-cache-size
* (x/foundation) [\#709](https://github.com/line/lbm-sdk/pull/709) add `gov mint` for x/foundation proposal
* (iavl) [\#738](https://github.com/line/lbm-sdk/pull/738) bump github.com/cosmos/iavl from v0.17.3 to v0.19.3
* (baseapp) [\#756](https://github.com/line/lbm-sdk/pull/756) Change to create chCheckTx with the value set in app config
* (x/foundation) [\#758](https://github.com/line/lbm-sdk/pull/758) add invariants to x/foundation

### Improvements
* (ostracon) [\#811](https://github.com/line/lbm-sdk/pull/811) bump up Ostracon from `2231684789c6e754744e3f10f8b41c96c4575ad1` to v1.0.7
* (x/auth) [\#776](https://github.com/line/lbm-sdk/pull/776) remove unused MsgEmpty
* (refactor) [\#493](https://github.com/line/lbm-sdk/pull/493) restructure x/consortium
* (server/grpc) [\#526](https://github.com/line/lbm-sdk/pull/526) add index field into TxResponse
* (cli) [\#535](https://github.com/line/lbm-sdk/pull/536) updated ostracon to v1.0.5; `unsafe-reset-all` command has been moved to the `ostracon` sub-command.
* (x/foundation) [\#597](https://github.com/line/lbm-sdk/pull/597) tidy up x/foundation
* (x/collection) [\#604](https://github.com/line/lbm-sdk/pull/604) add EventOwnerChanged and EventRootChanged
* (x/collection) [\#608](https://github.com/line/lbm-sdk/pull/608) remove new APIs on x/collection
* (x/token) [\#609](https://github.com/line/lbm-sdk/pull/609) remove new APIs on x/token
* (x/collection) [\#621](https://github.com/line/lbm-sdk/pull/621) add additional information into EventXXXChanged
* (x/token) [\#636](https://github.com/line/lbm-sdk/pull/636) add creator into x/token EventIssue
* (x/token) [\#637](https://github.com/line/lbm-sdk/pull/637) rename x/token events
* (x/collection) [\#639](https://github.com/line/lbm-sdk/pull/639) rename x/collection events
* (x/wasm) [\#661](https://github.com/line/lbm-sdk/pull/661) x/wasm refactoring - detaching the custom wasm proto part of lbm-sdk. (apply changes of [\#625](https://github.com/line/lbm-sdk/pull/625) and [\#655](https://github.com/line/lbm-sdk/pull/655))
* (refactor) [\#685](https://github.com/line/lbm-sdk/pull/685) remove x/foundation UpdateValidatorAuthsProposal
* (x/foundation) [\#686](https://github.com/line/lbm-sdk/pull/686) remove `Minthreshold` and `MinPercentage` from x/foundation config
* (x/foundation) [\#693](https://github.com/line/lbm-sdk/pull/693) add pool to the state of x/foundation
* (x/auth, client) [\#699](https://github.com/line/lbm-sdk/pull/699) Improvement on input validation of `req.Hash`
* (x/wasm,distribution) [\#696](https://github.com/line/lbm-sdk/pull/696) x/wasm,distribution - add checking a file size before reading it
* (x/foundation) [\#698](https://github.com/line/lbm-sdk/pull/698) update x/group relevant logic in x/foundation
* (x/auth,bank,foundation,wasm) [\#691](https://github.com/line/lbm-sdk/pull/691) change AccAddressFromBech32 to MustAccAddressFromBech32
* (x/wasm) [\#690](https://github.com/line/lbm-sdk/pull/690) fix to prevent accepting file name
* (cli) [\#708](https://github.com/line/lbm-sdk/pull/708) In CLI, allow 1 SIGN_MODE_DIRECT signer in transactions with multiple signers.
* (x/modules) [\#722](https://github.com/line/lbm-sdk/pull/722) Check error for `RegisterQueryHandlerClient` in all modules `RegisterGRPCGatewayRoutes`
* (x/bank) [\#716](https://github.com/line/lbm-sdk/pull/716) remove useless DenomMetadata key function
* (x/foundation) [\#704](https://github.com/line/lbm-sdk/pull/704) update x/foundation params
* (x/wasm)  [\#695](https://github.com/line/lbm-sdk/pull/695) fix to prevent external filesystem dependency of simulation
* (x/foundation) [\#729](https://github.com/line/lbm-sdk/pull/729) add UpdateParams to x/foundation
* (amino) [\#736](https://github.com/line/lbm-sdk/pull/736) apply the missing amino codec registratoin of cosmos-sdk
* (x/foundation) [\#744](https://github.com/line/lbm-sdk/pull/744) revisit foundation operator
* (store,x/wasm) [\#742](https://github.com/line/lbm-sdk/pull/742) fix to add error message in GetByteCode()
* (amino) [\#745](https://github.com/line/lbm-sdk/pull/745) apply the missing amino codec of `x/token`, `x/collection`, `x/wasm` and `x/foundation`
* (x/foundation) [\#757](https://github.com/line/lbm-sdk/pull/757) remove redundant granter from x/foundation events

### Bug Fixes
* (x/foundation) [\#772](https://github.com/line/lbm-sdk/pull/772) export x/foundation pool
* (baseapp) [\#781](https://github.com/line/lbm-sdk/pull/781) implement method `SetOption()` in baseapp
* (global) [\#782](https://github.com/line/lbm-sdk/pull/782) add unhandled return error handling
* (x/collection,x/token) [\#798](https://github.com/line/lbm-sdk/pull/798) Fix x/collection ModifyContract
* (ci) [\#803](https://github.com/line/lbm-sdk/pull/803) fix test flow to install libsodium
* (x/collection,token) [\#784](https://github.com/line/lbm-sdk/pull/784) Make field key matching in x/token & x/collection case-sensitive
* (x/wasm) [\#453](https://github.com/line/lbm-sdk/pull/453) modify wasm grpc query api path
* (client) [\#476](https://github.com/line/lbm-sdk/pull/476) change the default value of the client output format in the config
* (server/grpc) [\#516](https://github.com/line/lbm-sdk/pull/516) restore build norace flag
* (genesis) [\#517](https://github.com/line/lbm-sdk/pull/517) fix genesis auth account format(cosmos-sdk style -> lbm-sdk style)
* (x/token) [\#539](https://github.com/line/lbm-sdk/pull/539) fix the compatibility issues with daphne
* (x/foundation) [\#545](https://github.com/line/lbm-sdk/pull/545) fix genesis and support abstain
* (x/auth) [\#563](https://github.com/line/lbm-sdk/pull/563) fix unmarshal bug of `BaseAccountJSON`
* (client) [\#565](https://github.com/line/lbm-sdk/pull/565) fix the data race problem in `TestQueryABCIHeight`
* (x/token) [\#589](https://github.com/line/lbm-sdk/pull/589) fix naming collision in x/token enums
* (x/token) [\#599](https://github.com/line/lbm-sdk/pull/599) fix the order of events
* (x/wasm) [\#640](https://github.com/line/lbm-sdk/pull/640) remove legacy codes of wasm
* (amino) [\#635](https://github.com/line/lbm-sdk/pull/635) change some minor things that haven't been fixed in #549
* (store) [\#666](https://github.com/line/lbm-sdk/pull/666) change default `iavl-cache-size` and description
* (x/auth) [\#673](https://github.com/line/lbm-sdk/pull/673) fix max gas validation
* (simapp) [\#679](https://github.com/line/lbm-sdk/pull/679) fix the bug not setting `iavl-cache-size` value of `app.toml`
* (x/foundation) [\#687](https://github.com/line/lbm-sdk/pull/687) fix bugs on aborting x/foundation proposals
* (global) [\#694](https://github.com/line/lbm-sdk/pull/694) replace deprecated functions since go 1.16 or 1.17
* (x/bankplus) [\#705](https://github.com/line/lbm-sdk/pull/705) add missing blockedAddr checking in bankplus
* (x/foundation) [\#712](https://github.com/line/lbm-sdk/pull/712) fix x/foundation EndBlocker
* (x/feegrant) [\#720](https://github.com/line/lbm-sdk/pull/720) remove potential runtime panic in x/feegrant
* (baseapp) [\#724](https://github.com/line/lbm-sdk/pull/724) add checking pubkey type from validator params
* (x/staking) [\#726](https://github.com/line/lbm-sdk/pull/726) check allowedList size in StakeAuthorization.Accept()
* (x/staking) [\#728](https://github.com/line/lbm-sdk/pull/728) fix typo in unbondingToUnbonded() panic
* (crypto) [\#731](https://github.com/line/lbm-sdk/pull/731) remove VRFProve function
* (x/foundation) [\#732](https://github.com/line/lbm-sdk/pull/732) add verification on accounts into x/foundation Grants cli
* (x/foundation) [\#730](https://github.com/line/lbm-sdk/pull/730) prune stale x/foundation proposals at voting period end
* (cli) [\#734](https://github.com/line/lbm-sdk/pull/734) add restrictions on the number of args in the CLIs
* (client) [\#737](https://github.com/line/lbm-sdk/pull/737) check multisig key list to prevent unexpected key deletion
* (simapp) [\#752](https://github.com/line/lbm-sdk/pull/752) add x/distribution's module account into blockedAddr
* (x/auth) [\#754](https://github.com/line/lbm-sdk/pull/754) Fix wrong sequences in `sign-batch`
* (x/foundation) [\#761](https://github.com/line/lbm-sdk/pull/761) restore build norace flag
* (server) [\#763](https://github.com/line/lbm-sdk/pull/763) start telemetry independently from the API server

### Breaking Changes
* (cli) [\#773](https://github.com/line/lbm-sdk/pull/773) guide users to use generate-only in messages for x/foundation authority
* (x/foundation) [\#790](https://github.com/line/lbm-sdk/pull/790) fix case of gov_mint_left_count in x/foundation
* (proto) [\#564](https://github.com/line/lbm-sdk/pull/564) change gRPC path to original cosmos path
* (global) [\#603](https://github.com/line/lbm-sdk/pull/603) apply types/address.go from cosmos-sdk@v0.45.1
* (amino) [\#600](https://github.com/line/lbm-sdk/pull/600) change amino codec path from `lbm-sdk/` to `cosmos-sdk/`
* (ostracon) [\#610](https://github.com/line/lbm-sdk/pull/610) apply change of prefix of key name in ostracon
* (ostracon) [\#614](https://github.com/line/lbm-sdk/pull/614) apply Ostracon's changes that replace `StakingPower` with `VotingPower` and `StakingPower` with `VotingPower`
* (proto) [\#617](https://github.com/line/lbm-sdk/pull/617) change wasm gRPC path to original `cosmwasm` path.
* (proto) [\#627](https://github.com/line/lbm-sdk/pull/627) revert changes in x/slashing proto

### Build, CI
* (ci) [\#779](https://github.com/line/lbm-sdk/pull/779) change github action trigger rules for `release/*` and `rc*/*` branches
* (ci) [\#457](https://github.com/line/lbm-sdk/pull/457), [\#471](https://github.com/line/lbm-sdk/pull/471) add swagger check
* (ci) [\#469](https://github.com/line/lbm-sdk/pull/469) publish docker image on tag push
* (ci) [\#580](https://github.com/line/lbm-sdk/pull/580) fix the problem that the registered docker image couldn't run on M1.
* (simapp) [\#591](https://github.com/line/lbm-sdk/pull/591) chore: add x/wasm module to simapp
* (ci) [\#618](https://github.com/line/lbm-sdk/pull/618) remove stale action
* (ci) [\#619](https://github.com/line/lbm-sdk/pull/619) change the Dockerfile to use the downloaded static library

### Document Updates
* (docs) [\#766](https://github.com/line/lbm-sdk/pull/766) fix submit-proposal command on x/foundation
* (docs) [\#802](https://github.com/line/lbm-sdk/pull/802) update x/foundation documentation
* (docs) [\#483](https://github.com/line/lbm-sdk/pull/483) update documents on x/stakingplus
* (docs) [\#490](https://github.com/line/lbm-sdk/pull/490) update documents on x/consortium
* (docs) [\#602](https://github.com/line/lbm-sdk/pull/602) update outdated events in specs
* (docs) [\#721](https://github.com/line/lbm-sdk/pull/721) update x/foundation specification
* (docs) [\#748](https://github.com/line/lbm-sdk/pull/748) add `GovMint` to x/foundation specification


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
