### PR TITLE
feat: add calculate instantiate cost function into get contract env api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+* (x/wasm) [\#835](https://github.com/line/lbm-sdk/pull/835) add calculate instantiate cost function into get contract env api
 * (global) [\#764](https://github.com/line/lbm-sdk/pull/764) update dependencies of packages in dynamic link branch
 * (x/wasm) [\#669](https://github.com/line/lbm-sdk/pull/669) update wasmvm and update contracts for tests
 * (x/wasm) [\#656](https://github.com/line/lbm-sdk/pull/656) add unit test for dynamic link when callee fails

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/jhump/protoreflect v1.10.3
 	github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6
-	github.com/line/wasmvm v1.0.0-0.10.0.0.20221206064228-ce0757a8da21
+	github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a
 	github.com/magiconair/properties v1.8.6
 	github.com/mailru/easyjson v0.7.7
 	github.com/mattn/go-isatty v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6 h1:WKz4yaIW+TJgJv5uhmrHYC3UnohDHlXDT6GccvgV0AA=
 github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6/go.mod h1:8gnHCqwRjbJfhVtQkl7KIfcubtpsIEmiN0u91B4EYWY=
-github.com/line/wasmvm v1.0.0-0.10.0.0.20221206064228-ce0757a8da21 h1:ptPbwqWu139S7K1jh8NaGYbE6zNKLW0zwvJDGhfjHSQ=
-github.com/line/wasmvm v1.0.0-0.10.0.0.20221206064228-ce0757a8da21/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
+github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a h1:2wgOMBVR5PObP597P9n/ZkSOUVy3MDjgJH6hR3eqBJE=
+github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/x/wasm/dynamic_link_test.go
+++ b/x/wasm/dynamic_link_test.go
@@ -50,11 +50,11 @@ func TestDynamicPingPongWorks(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "callee",
-		Msg: []byte(`{}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "callee",
+		Msg:    []byte(`{}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -64,11 +64,11 @@ func TestDynamicPingPongWorks(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "caller",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "caller",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)
@@ -127,11 +127,11 @@ func TestDynamicReEntrancyFails(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "callee",
-		Msg: []byte(`{}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "callee",
+		Msg:    []byte(`{}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -141,11 +141,11 @@ func TestDynamicReEntrancyFails(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "caller",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "caller",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)
@@ -194,11 +194,11 @@ func TestDynamicLinkInterfaceValidation(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "callee",
-		Msg: []byte(`{}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "callee",
+		Msg:    []byte(`{}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -208,11 +208,11 @@ func TestDynamicLinkInterfaceValidation(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "caller",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "caller",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)
@@ -275,11 +275,11 @@ func TestDynamicCallAndTraditionalQueryWork(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "number",
-		Msg: []byte(`{"value":21}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "number",
+		Msg:    []byte(`{"value":21}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -289,11 +289,11 @@ func TestDynamicCallAndTraditionalQueryWork(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "call-number",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "call-number",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)
@@ -375,11 +375,11 @@ func TestDynamicCallWithWriteFailsByQuery(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "number",
-		Msg: []byte(`{"value":21}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "number",
+		Msg:    []byte(`{"value":21}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -389,11 +389,11 @@ func TestDynamicCallWithWriteFailsByQuery(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "call-number",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "call-number",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)
@@ -442,11 +442,11 @@ func TestDynamicCallCalleeFails(t *testing.T) {
 
 	// instantiate callee contract
 	instantiateCalleeMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  calleeCodeId,
-		Label:   "callee",
-		Msg: []byte(`{}`),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: calleeCodeId,
+		Label:  "callee",
+		Msg:    []byte(`{}`),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCalleeMsg)
 	require.NoError(t, err)
@@ -456,11 +456,11 @@ func TestDynamicCallCalleeFails(t *testing.T) {
 	// instantiate caller contract
 	cosmwasmInstantiateCallerMsg := fmt.Sprintf(`{"callee_addr":"%s"}`, calleeContractAddress)
 	instantiateCallerMsg := &MsgInstantiateContract{
-		Sender:  addr1,
-		CodeID:  callerCodeId,
-		Label:   "caller",
-		Msg: []byte(cosmwasmInstantiateCallerMsg),
-		Funds:   nil,
+		Sender: addr1,
+		CodeID: callerCodeId,
+		Label:  "caller",
+		Msg:    []byte(cosmwasmInstantiateCallerMsg),
+		Funds:  nil,
 	}
 	res, err = h(data.ctx, instantiateCallerMsg)
 	require.NoError(t, err)

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -9,7 +9,6 @@ import (
 )
 
 type cosmwasmAPIImpl struct {
-	gasMultiplier GasMultiplier
 	keeper        *Keeper
 	ctx           *sdk.Context
 }
@@ -27,7 +26,8 @@ var (
 )
 
 func (a cosmwasmAPIImpl) humanAddress(canon []byte) (string, uint64, error) {
-	gas := a.gasMultiplier.FromWasmVMGas(5)
+	gasMultiplier := a.keeper.getGasMultiplier(*a.ctx)
+	gas := gasMultiplier.ToWasmVMGas(5)
 	if err := sdk.VerifyAddressFormat(canon); err != nil {
 		return "", gas, err
 	}
@@ -37,15 +37,18 @@ func (a cosmwasmAPIImpl) humanAddress(canon []byte) (string, uint64, error) {
 
 func (a cosmwasmAPIImpl) canonicalAddress(human string) ([]byte, uint64, error) {
 	bz, err := sdk.AccAddressFromBech32(human)
-	return bz, a.gasMultiplier.ToWasmVMGas(4), err
+	gasMultiplier := a.keeper.getGasMultiplier(*a.ctx)
+	return bz, gasMultiplier.ToWasmVMGas(4), err
 }
 
-func (a cosmwasmAPIImpl) GetContractEnv(contractAddrStr string, inputSize uint64) (wasmvm.Env, *wasmvm.Cache, wasmvm.KVStore, wasmvm.Querier, wasmvm.GasMeter, []byte, uint64, uint64, error) {
+func (a cosmwasmAPIImpl) getContractEnv(contractAddrStr string, inputSize uint64) (wasmvm.Env, *wasmvm.Cache, wasmvm.KVStore, wasmvm.Querier, wasmvm.GasMeter, []byte, uint64, uint64, error) {
 	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
 	contractInfo, codeInfo, prefixStore, err := a.keeper.contractInstance(*a.ctx, contractAddr)
 	if err != nil {
 		return wasmvm.Env{}, nil, nil, nil, nil, wasmvm.Checksum{}, 0, 0, err
 	}
+
+	gasMultiplier := a.keeper.getGasMultiplier(*a.ctx)
 
 	cache := a.keeper.wasmVM.GetCache()
 	if cache == nil {
@@ -53,13 +56,13 @@ func (a cosmwasmAPIImpl) GetContractEnv(contractAddrStr string, inputSize uint64
 	}
 
 	// prepare querier
-	querier := NewQueryHandler(*a.ctx, a.keeper.wasmVMQueryHandler, contractAddr, a.gasMultiplier)
+	querier := NewQueryHandler(*a.ctx, a.keeper.wasmVMQueryHandler, contractAddr, gasMultiplier)
 
 	// this gas cost is temporal value defined by
 	// https://github.com/line/lbm-sdk/runs/8150140720?check_suite_focus=true#step:5:483
 	// Before release, it is adjusted by benchmark taken in environment similar to the nodes.
-	gas := a.gasMultiplier.ToWasmVMGas(11)
-	instantiateCost := a.gasMultiplier.ToWasmVMGas(a.keeper.instantiateContractCosts(a.keeper.gasRegister, *a.ctx, a.keeper.IsPinnedCode(*a.ctx, contractInfo.CodeID), int(inputSize)))
+	gas := gasMultiplier.ToWasmVMGas(11)
+	instantiateCost := gasMultiplier.ToWasmVMGas(a.keeper.instantiateContractCosts(a.keeper.gasRegister, *a.ctx, a.keeper.IsPinnedCode(*a.ctx, contractInfo.CodeID), int(inputSize)))
 	wasmStore := types.NewWasmStore(prefixStore)
 	env := types.NewEnv(*a.ctx, contractAddr)
 
@@ -68,13 +71,12 @@ func (a cosmwasmAPIImpl) GetContractEnv(contractAddrStr string, inputSize uint64
 
 func (k Keeper) cosmwasmAPI(ctx sdk.Context) wasmvm.GoAPI {
 	x := cosmwasmAPIImpl{
-		gasMultiplier: k.getGasMultiplier(ctx),
-		keeper:        &k,
-		ctx:           &ctx,
+		keeper: &k,
+		ctx:    &ctx,
 	}
 	return wasmvm.GoAPI{
 		HumanAddress:     x.humanAddress,
 		CanonicalAddress: x.canonicalAddress,
-		GetContractEnv:   x.GetContractEnv,
+		GetContractEnv:   x.getContractEnv,
 	}
 }

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -9,8 +9,8 @@ import (
 )
 
 type cosmwasmAPIImpl struct {
-	keeper        *Keeper
-	ctx           *sdk.Context
+	keeper *Keeper
+	ctx    *sdk.Context
 }
 
 const (

--- a/x/wasm/keeper/api_test.go
+++ b/x/wasm/keeper/api_test.go
@@ -31,13 +31,13 @@ func TestAPIHumanAddress(t *testing.T) {
 		result, gas, err := api.HumanAddress(bz)
 		require.NoError(t, err)
 		assert.Equal(t, addr, result)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * 5, gas)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*5, gas)
 	})
 
 	t.Run("invalid address", func(t *testing.T) {
 		_, gas, err := api.HumanAddress([]byte("invalid_address"))
 		require.Error(t, err)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * 5, gas)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*5, gas)
 	})
 }
 
@@ -52,13 +52,13 @@ func TestAPICanonicalAddress(t *testing.T) {
 		result, gas, err := api.CanonicalAddress(addr)
 		require.NoError(t, err)
 		assert.Equal(t, expected.Bytes(), result)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * 4, gas)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*4, gas)
 	})
 
-	t.Run("invalid address", func(t * testing.T) {
+	t.Run("invalid address", func(t *testing.T) {
 		_, gas, err := api.CanonicalAddress("invalid_address")
 		assert.Error(t, err)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * 4, gas)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*4, gas)
 	})
 }
 
@@ -101,11 +101,11 @@ func TestAPIGetContractEnv(t *testing.T) {
 		assert.Equal(t, []byte{uint8(0), uint8(0), uint8(0), uint8(value)}, store.Get([]byte("number")))
 
 		queryMsg := []byte(`{"number":{}}`)
-		query := wasmvmtypes.QueryRequest {
-			Wasm: &wasmvmtypes.WasmQuery {
-				Smart: &wasmvmtypes.SmartQuery {
+		query := wasmvmtypes.QueryRequest{
+			Wasm: &wasmvmtypes.WasmQuery{
+				Smart: &wasmvmtypes.SmartQuery{
 					ContractAddr: contractAddr.String(),
-					Msg: queryMsg,
+					Msg:          queryMsg,
 				},
 			},
 		}
@@ -114,12 +114,12 @@ func TestAPIGetContractEnv(t *testing.T) {
 		assert.Equal(t, []byte(`{"value":42}`), queryResult)
 
 		expectedInstantiateCost := keepers.WasmKeeper.instantiateContractCosts(keepers.WasmKeeper.gasRegister, ctx, false, msgLen)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * expectedInstantiateCost, instantiateCost)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*expectedInstantiateCost, instantiateCost)
 
-		assert.Equal(t, wasmtype.DefaultGasMultiplier * 11, gas)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier*11, gas)
 	})
 
-	t.Run("non-existed contract", func(t *testing.T){
+	t.Run("non-existed contract", func(t *testing.T) {
 		nonExistedContractAddr := "link1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyu0w3p"
 		require.NotEqual(t, nonExistedContractAddr, contractAddr)
 		_, _, _, _, _, _, _, _, err := api.GetContractEnv(nonExistedContractAddr, uint64(msgLen))

--- a/x/wasm/keeper/api_test.go
+++ b/x/wasm/keeper/api_test.go
@@ -1,0 +1,128 @@
+package keeper
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	sdk "github.com/line/lbm-sdk/types"
+	wasmtype "github.com/line/lbm-sdk/x/wasm/types"
+	wasmvm "github.com/line/wasmvm"
+	wasmvmapi "github.com/line/wasmvm/api"
+	wasmvmtypes "github.com/line/wasmvm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newAPI(t *testing.T) wasmvm.GoAPI {
+	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
+	return keepers.WasmKeeper.cosmwasmAPI(ctx)
+}
+
+func TestAPIHumanAddress(t *testing.T) {
+	// prepare API
+	api := newAPI(t)
+
+	t.Run("valid address", func(t *testing.T) {
+		// address for alice in testnet
+		addr := "link1twsfmuj28ndph54k4nw8crwu8h9c8mh3rtx705"
+		bz, err := sdk.AccAddressFromBech32(addr)
+		require.NoError(t, err)
+		result, gas, err := api.HumanAddress(bz)
+		require.NoError(t, err)
+		assert.Equal(t, addr, result)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * 5, gas)
+	})
+
+	t.Run("invalid address", func(t *testing.T) {
+		_, gas, err := api.HumanAddress([]byte("invalid_address"))
+		require.Error(t, err)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * 5, gas)
+	})
+}
+
+func TestAPICanonicalAddress(t *testing.T) {
+	// prepare API
+	api := newAPI(t)
+
+	t.Run("valid address", func(t *testing.T) {
+		addr := "link1twsfmuj28ndph54k4nw8crwu8h9c8mh3rtx705"
+		expected, err := sdk.AccAddressFromBech32(addr)
+		require.NoError(t, err)
+		result, gas, err := api.CanonicalAddress(addr)
+		require.NoError(t, err)
+		assert.Equal(t, expected.Bytes(), result)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * 4, gas)
+	})
+
+	t.Run("invalid address", func(t * testing.T) {
+		_, gas, err := api.CanonicalAddress("invalid_address")
+		assert.Error(t, err)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * 4, gas)
+	})
+}
+
+func TestAPIGetContractEnv(t *testing.T) {
+	// prepare ctx and keeper
+	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
+
+	// instantiate a number contract
+	numberWasm, err := ioutil.ReadFile("../testdata/number.wasm")
+	require.NoError(t, err)
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
+	em := sdk.NewEventManager()
+	codeID, err := keepers.ContractKeeper.Create(ctx.WithEventManager(em), creator, numberWasm, nil)
+	require.NoError(t, err)
+	value := 42
+	initMsg := []byte(fmt.Sprintf(`{"value":%d}`, value))
+	contractAddr, _, err := keepers.ContractKeeper.Instantiate(ctx.WithEventManager(em), codeID, creator, nil, initMsg, "number", nil)
+	require.NoError(t, err)
+	msgLen := 101010
+
+	// prepare API
+	api := keepers.WasmKeeper.cosmwasmAPI(ctx)
+
+	t.Run("succeed", func(t *testing.T) {
+		// omitted value is MultipliedGasMeter. It is not tested here.
+		env, cache, store, querier, _, hash, instantiateCost, gas, err := api.GetContractEnv(contractAddr.String(), uint64(msgLen))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(ctx.BlockHeight()), env.Block.Height)
+		assert.Equal(t, uint64(ctx.BlockTime().UnixNano()), env.Block.Time)
+		assert.Equal(t, ctx.ChainID(), env.Block.ChainID)
+		assert.Equal(t, contractAddr.String(), env.Contract.Address)
+
+		code, err := wasmvmapi.GetCode(*cache, hash)
+		assert.Equal(t, numberWasm, code)
+
+		// "number" comes from https://github.com/line/cosmwasm/blob/d08b5a59115cc3d28f375b7425b902bfd1dac6a4/contracts/number/src/contract.rs#L9
+		assert.Equal(t, []byte{uint8(0), uint8(0), uint8(0), uint8(value)}, store.Get([]byte("number")))
+
+		queryMsg := []byte(`{"number":{}}`)
+		query := wasmvmtypes.QueryRequest {
+			Wasm: &wasmvmtypes.WasmQuery {
+				Smart: &wasmvmtypes.SmartQuery {
+					ContractAddr: contractAddr.String(),
+					Msg: queryMsg,
+				},
+			},
+		}
+		queryResult, err := querier.Query(query, 10_000_000_000_000)
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"value":42}`), queryResult)
+
+		expectedInstantiateCost := keepers.WasmKeeper.instantiateContractCosts(keepers.WasmKeeper.gasRegister, ctx, false, msgLen)
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * expectedInstantiateCost, instantiateCost)
+
+		assert.Equal(t, wasmtype.DefaultGasMultiplier * 11, gas)
+	})
+
+	t.Run("non-existed contract", func(t *testing.T){
+		nonExistedContractAddr := "link1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyu0w3p"
+		require.NotEqual(t, nonExistedContractAddr, contractAddr)
+		_, _, _, _, _, _, _, _, err := api.GetContractEnv(nonExistedContractAddr, uint64(msgLen))
+		require.Error(t, err)
+	})
+}

--- a/x/wasm/keeper/bench_test.go
+++ b/x/wasm/keeper/bench_test.go
@@ -95,7 +95,7 @@ func BenchmarkAPI(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _, _, _, _, _, _, err := api.GetContractEnv(addrStr)
+			_, _, _, _, _, _, _, _, err := api.GetContractEnv(addrStr, 0)
 			require.NoError(b, err)
 		}
 	})
@@ -118,6 +118,7 @@ func BenchmarkAPI(b *testing.B) {
 		}
 	})
 }
+
 // Calculate the time it takes to compile some wasm code the first time.
 // This will help us adjust pricing for UploadCode
 func BenchmarkCompilation(b *testing.B) {

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -390,7 +390,7 @@ func TestInstantiate(t *testing.T) {
 
 	gasAfter := ctx.GasMeter().GasConsumed()
 	if types.EnableGasVerification {
-		require.Equal(t, uint64(0x18bfc), gasAfter-gasBefore)
+		require.Equal(t, uint64(0x18c06), gasAfter-gasBefore)
 	}
 
 	// ensure it is stored properly

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -722,6 +722,7 @@ var keyCounter uint64
 
 // we need to make this deterministic (same every test run), as encoded address size and thus gas cost,
 // depends on the actual bytes (due to ugly CanonicalAddress encoding)
+//
 //nolint:unparam
 func keyPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
 	keyCounter++

--- a/x/wasm/simulation/operations.go
+++ b/x/wasm/simulation/operations.go
@@ -14,6 +14,7 @@ import (
 )
 
 // Simulation operation weights constants
+//
 //nolint:gosec
 const (
 	OpWeightMsgStoreCode           = "op_weight_msg_store_code"

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -128,10 +128,11 @@ func (c *ContractInfo) SetExtension(ext ContractInfoExtension) error {
 
 // ReadExtension copies the extension value to the pointer passed as argument so that there is no need to cast
 // For example with a custom extension of type `MyContractDetails` it will look as following:
-// 		var d MyContractDetails
-//		if err := info.ReadExtension(&d); err != nil {
-//			return nil, sdkerrors.Wrap(err, "extension")
-//		}
+//
+//	var d MyContractDetails
+//	if err := info.ReadExtension(&d); err != nil {
+//		return nil, sdkerrors.Wrap(err, "extension")
+//	}
 func (c *ContractInfo) ReadExtension(e ContractInfoExtension) error {
 	rv := reflect.ValueOf(e)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes GetContractEnv wasm API for x/wasm able to calculate instantiate cost. This function uses the input length in the calculation, so this PR adds it and arg for return as new args of the GetContractEnv.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is used for costing instantiate cost to callings of dynamic functions (https://github.com/line/cosmwasm/issues/257). It also works as the limit of the length of inputs of callings of dynamic functions.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This PR modifies some unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
