### PR TITLE
fix parse nodeID correctly in init_node.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 * (client) [\#817](https://github.com/line/lbm-sdk/pull/817) remove support for composite (BLS) type
-* (chore) [\#842](https://github.com/line/lbm-sdk/pull/842) change index number to make correct node address in init_node.sh 
+* (script) [\#842](https://github.com/line/lbm-sdk/pull/842) change index number to make correct node address in init_node.sh 
 
 ### Breaking Changes
 * (rest) [\#807](https://github.com/line/lbm-sdk/pull/807) remove legacy REST API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 * (client) [\#817](https://github.com/line/lbm-sdk/pull/817) remove support for composite (BLS) type
+* (chore) [\#842](https://github.com/line/lbm-sdk/pull/842) change index number to make correct node address in init_node.sh 
 
 ### Breaking Changes
 * (rest) [\#807](https://github.com/line/lbm-sdk/pull/807) remove legacy REST API

--- a/init_node.sh
+++ b/init_node.sh
@@ -124,7 +124,7 @@ for ((i = 0; i < N; i++))
       sed -i 's/addr_book_strict = true/addr_book_strict = false/g' ${CHAIN_DIR}/config/config.toml  # for local test
       sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/g' ${CHAIN_DIR}/config/config.toml  # allow duplicated ip
 
-      sed -i 's#'"${MEMO}"'#'"${MEMO_SPLIT[1]}"':'"${P2P_PORT}"'#g' ${CHAIN_0_DIR}/config/config.toml  # change port of persistent_peers
+      sed -i 's#'"${MEMO}"'#'"${MEMO_SPLIT[0]}"':'"${P2P_PORT}"'#g' ${CHAIN_0_DIR}/config/config.toml  # change port of persistent_peers
 
       sed -i 's/pruning = "default"/pruning = "nothing"/g' ${CHAIN_DIR}/config/app.toml
       sed -i 's#"0.0.0.0:9091"#"0.0.0.0:'"${GRPC_WEB_PORT}"'"#g' ${CHAIN_DIR}/config/app.toml
@@ -138,7 +138,7 @@ for ((i = 0; i < N; i++))
       sed -i '' 's/addr_book_strict = true/addr_book_strict = false/g' ${CHAIN_DIR}/config/config.toml  # for local test
       sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/g' ${CHAIN_DIR}/config/config.toml  # allow duplicated ip
       
-      sed -i '' 's#'"${MEMO}"'#'"${MEMO_SPLIT[1]}"':'"${P2P_PORT}"'#g' ${CHAIN_0_DIR}/config/config.toml  # change port of persistent_peers
+      sed -i '' 's#'"${MEMO}"'#'"${MEMO_SPLIT[0]}"':'"${P2P_PORT}"'#g' ${CHAIN_0_DIR}/config/config.toml  # change port of persistent_peers
       
       sed -i '' 's/pruning = "default"/pruning = "nothing"/g' ${CHAIN_DIR}/config/app.toml
       sed -i '' 's#"0.0.0.0:9091"#"0.0.0.0:'"${GRPC_WEB_PORT}"'"#g' ${CHAIN_DIR}/config/app.toml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #838 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When creating multiple nodes with init_nodes.sh, the first node simapp0 should have other peers address in persistent_pears. peers address were get by parsing gentx body memo like below.
```
    MEMO=`sed 's/"//g' <<< \`cat ${GENTXS_DIR}/${MONIKER}.json | jq '.body.memo'\``
    MEMO_SPLIT=(`echo ${MEMO} | tr ":" "\n"`)
```
The way to get the address from the memo was correct, but the index was wrong.

In this PR, index changed to get correct address.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![스크린샷 2022-12-26 오후 3 51 03](https://user-images.githubusercontent.com/55660267/209514125-32e9cb19-2561-4430-8011-382b40112439.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
