### PR TITLE
Map Ostracon:ErrTxInMap to lbm-sdk:ErrTxInMempoolCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 * (cosmovisor) [\#792](https://github.com/line/lbm-sdk/pull/792) Use upstream's cosmovisor
 * (server) [\#821](https://github.com/line/lbm-sdk/pull/821) Get validator pubkey considering KMS
+* (client) [\#890](https://github.com/line/lbm-sdk/pull/890) Map Ostracon:ErrTxInMap to lbm-sdk:ErrTxInMempoolCache
 
 ### Bug Fixes
 * (client) [\#817](https://github.com/line/lbm-sdk/pull/817) remove support for composite (BLS) type

--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -56,7 +56,8 @@ func CheckTendermintError(err error, tx octypes.Tx) *sdk.TxResponse {
 	txHash := fmt.Sprintf("%X", tx.Hash())
 
 	switch {
-	case strings.Contains(errStr, strings.ToLower(mempool.ErrTxInCache.Error())):
+	case strings.Contains(errStr, strings.ToLower(mempool.ErrTxInCache.Error())),
+		strings.Contains(errStr, strings.ToLower(mempool.ErrTxInMap.Error())):
 		return &sdk.TxResponse{
 			Code:      sdkerrors.ErrTxInMempoolCache.ABCICode(),
 			Codespace: sdkerrors.ErrTxInMempoolCache.Codespace(),
@@ -74,13 +75,6 @@ func CheckTendermintError(err error, tx octypes.Tx) *sdk.TxResponse {
 		return &sdk.TxResponse{
 			Code:      sdkerrors.ErrTxTooLarge.ABCICode(),
 			Codespace: sdkerrors.ErrTxTooLarge.Codespace(),
-			TxHash:    txHash,
-		}
-
-	case strings.Contains(errStr, strings.ToLower(mempool.ErrTxInMap.Error())):
-		return &sdk.TxResponse{
-			Code:      sdkerrors.ErrTxInMempoolCache.ABCICode(),
-			Codespace: sdkerrors.ErrTxInMempoolCache.Codespace(),
 			TxHash:    txHash,
 		}
 

--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -77,6 +77,13 @@ func CheckTendermintError(err error, tx octypes.Tx) *sdk.TxResponse {
 			TxHash:    txHash,
 		}
 
+	case strings.Contains(errStr, strings.ToLower(mempool.ErrTxInMap.Error())):
+		return &sdk.TxResponse{
+			Code:      sdkerrors.ErrTxInMempoolCache.ABCICode(),
+			Codespace: sdkerrors.ErrTxInMempoolCache.Codespace(),
+			TxHash:    txHash,
+		}
+
 	default:
 		return nil
 	}

--- a/client/broadcast_test.go
+++ b/client/broadcast_test.go
@@ -44,6 +44,7 @@ func CreateContextWithErrorAndMode(err error, mode string) Context {
 func TestBroadcastError(t *testing.T) {
 	errors := map[error]uint32{
 		mempool.ErrTxInCache:       sdkerrors.ErrTxInMempoolCache.ABCICode(),
+		mempool.ErrTxInMap:         sdkerrors.ErrTxInMempoolCache.ABCICode(),
 		mempool.ErrTxTooLarge{}:    sdkerrors.ErrTxTooLarge.ABCICode(),
 		mempool.ErrMempoolIsFull{}: sdkerrors.ErrMempoolIsFull.ABCICode(),
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
lbm-sdk needs to be mapped for new errors in ostracon([ErrTxInMap](https://github.com/line/ostracon/blob/v1.0.8/mempool/errors.go#L10)).
For this error, lbm-sdk maps errors in [types/errors/errors.go](https://github.com/line/lbm-sdk/blob/main/types/errors/errors.go) to make it easier for users to handle.

An implementation concern is whether ErrInTxMempoolCache fully explains this error.
- For cosmos-sdk compatibility and lbm-sdk interface retention
- "ErrInTxMempoolCache" is insufficient, but the message "tx already in mempool" is enough to explain

For this reason, I mapped it to ErrTxInMempoolCache, but I think renaming this error to ErrTxInMempool is also a way.

closes: #810 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
