### PR TITLE
fix: change the default params of x/collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (cosmovisor) [\#792](https://github.com/line/lbm-sdk/pull/792) Use upstream's cosmovisor
 * (server) [\#821](https://github.com/line/lbm-sdk/pull/821) Get validator pubkey considering KMS
 * (client) [\#890](https://github.com/line/lbm-sdk/pull/890) Map Ostracon:ErrTxInMap to lbm-sdk:ErrTxInMempoolCache
+* (x/collection) [\#894](https://github.com/line/lbm-sdk/pull/894) Change the default params of x/collection
 
 ### Bug Fixes
 * (client) [\#817](https://github.com/line/lbm-sdk/pull/817) remove support for composite (BLS) type

--- a/x/collection/client/testutil/suite.go
+++ b/x/collection/client/testutil/suite.go
@@ -63,6 +63,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	gs.Params = params
 
 	gsBz, err := s.cfg.Codec.MarshalJSON(&gs)
+	s.Require().NoError(err)
 	s.cfg.GenesisState[collection.ModuleName] = gsBz
 
 	s.network = network.New(s.T(), s.cfg)

--- a/x/collection/client/testutil/suite.go
+++ b/x/collection/client/testutil/suite.go
@@ -53,8 +53,20 @@ func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 
+	var gs collection.GenesisState
+	s.Require().NoError(s.cfg.Codec.UnmarshalJSON(s.cfg.GenesisState[collection.ModuleName], &gs))
+
+	params := collection.Params{
+		DepthLimit: 4,
+		WidthLimit: 4,
+	}
+	gs.Params = params
+
+	gsBz, err := s.cfg.Codec.MarshalJSON(&gs)
+	s.cfg.GenesisState[collection.ModuleName] = gsBz
+
 	s.network = network.New(s.T(), s.cfg)
-	_, err := s.network.WaitForHeight(1)
+	_, err = s.network.WaitForHeight(1)
 	s.Require().NoError(err)
 
 	s.vendor = s.createAccount("vendor")

--- a/x/collection/genesis.go
+++ b/x/collection/genesis.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	DefaultDepthLimit = 3
-	DefaultWidthLimit = 8
+	DefaultDepthLimit = 1
+	DefaultWidthLimit = 4
 )
 
 // ValidateGenesis check the given genesis state has no integrity issues

--- a/x/collection/keeper/genesis.go
+++ b/x/collection/keeper/genesis.go
@@ -7,7 +7,7 @@ import (
 
 // InitGenesis new collection genesis
 func (k Keeper) InitGenesis(ctx sdk.Context, data *collection.GenesisState) {
-	k.setParams(ctx, data.Params)
+	k.SetParams(ctx, data.Params)
 
 	for _, contract := range data.Contracts {
 		k.setContract(ctx, contract)

--- a/x/collection/keeper/keeper_test.go
+++ b/x/collection/keeper/keeper_test.go
@@ -35,7 +35,7 @@ type KeeperTestSuite struct {
 
 	depthLimit int
 
-	numNFTs int
+	numNFTs  int
 	numRoots int
 }
 

--- a/x/collection/keeper/keeper_test.go
+++ b/x/collection/keeper/keeper_test.go
@@ -33,7 +33,9 @@ type KeeperTestSuite struct {
 
 	balance sdk.Int
 
-	numNFTs  int
+	depthLimit int
+
+	numNFTs int
 	numRoots int
 }
 
@@ -64,6 +66,12 @@ func (s *KeeperTestSuite) SetupTest() {
 
 	s.queryServer = keeper.NewQueryServer(s.keeper)
 	s.msgServer = keeper.NewMsgServer(s.keeper)
+
+	s.depthLimit = 4
+	s.keeper.SetParams(s.ctx, collection.Params{
+		DepthLimit: uint32(s.depthLimit),
+		WidthLimit: 4,
+	})
 
 	addresses := []*sdk.AccAddress{
 		&s.vendor,
@@ -130,11 +138,11 @@ func (s *KeeperTestSuite) SetupTest() {
 	}
 	// 1 for the successful attach, 2 for the failure
 	remainders := 1 + 2
-	s.numNFTs = collection.DefaultDepthLimit + remainders
+	s.numNFTs = s.depthLimit + remainders
 	// 3 chains, and each chain has depth_limit, 1 and 2 of its length.
 	s.numRoots = 3
 	for _, to := range []sdk.AccAddress{s.customer, s.operator, s.vendor} {
-		tokens, err := s.keeper.MintNFT(s.ctx, s.contractID, to, newParams(s.nftClassID, collection.DefaultDepthLimit))
+		tokens, err := s.keeper.MintNFT(s.ctx, s.contractID, to, newParams(s.nftClassID, s.depthLimit))
 		s.Require().NoError(err)
 
 		// create a chain of its length depth_limit

--- a/x/collection/keeper/msg_server_test.go
+++ b/x/collection/keeper/msg_server_test.go
@@ -1035,7 +1035,7 @@ func (s *KeeperTestSuite) TestMsgAttach() {
 	}{
 		"valid request": {
 			contractID: s.contractID,
-			subjectID:  collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
+			subjectID:  collection.NewNFTID(s.nftClassID, s.depthLimit+1),
 			targetID:   collection.NewNFTID(s.nftClassID, 1),
 		},
 		"contract not found": {
@@ -1131,7 +1131,7 @@ func (s *KeeperTestSuite) TestMsgOperatorAttach() {
 		"valid request": {
 			contractID: s.contractID,
 			operator:   s.operator,
-			subjectID:  collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
+			subjectID:  collection.NewNFTID(s.nftClassID, s.depthLimit+1),
 			targetID:   collection.NewNFTID(s.nftClassID, 1),
 		},
 		"contract not found": {
@@ -1144,7 +1144,7 @@ func (s *KeeperTestSuite) TestMsgOperatorAttach() {
 		"not authorized": {
 			contractID: s.contractID,
 			operator:   s.vendor,
-			subjectID:  collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
+			subjectID:  collection.NewNFTID(s.nftClassID, s.depthLimit+1),
 			targetID:   collection.NewNFTID(s.nftClassID, 1),
 			err:        collection.ErrCollectionNotApproved,
 		},

--- a/x/collection/keeper/nft_test.go
+++ b/x/collection/keeper/nft_test.go
@@ -13,8 +13,8 @@ func (s *KeeperTestSuite) TestAttach() {
 	}{
 		"valid request": {
 			contractID: s.contractID,
-			subject:    collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
-			target:     collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit),
+			subject:    collection.NewNFTID(s.nftClassID, s.depthLimit+1),
+			target:     collection.NewNFTID(s.nftClassID, s.depthLimit),
 		},
 		"not owner of subject": {
 			contractID: s.contractID,
@@ -24,19 +24,19 @@ func (s *KeeperTestSuite) TestAttach() {
 		},
 		"target not found": {
 			contractID: s.contractID,
-			subject:    collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
+			subject:    collection.NewNFTID(s.nftClassID, s.depthLimit+1),
 			target:     collection.NewNFTID(s.nftClassID, s.numNFTs*3+1),
 			err:        collection.ErrTokenNotExist,
 		},
 		"result exceeds the limit": {
 			contractID: s.contractID,
-			subject:    collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+2),
-			target:     collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit),
+			subject:    collection.NewNFTID(s.nftClassID, s.depthLimit+2),
+			target:     collection.NewNFTID(s.nftClassID, s.depthLimit),
 			err:        collection.ErrCompositionTooDeep,
 		},
 		"not owner of target": {
 			contractID: s.contractID,
-			subject:    collection.NewNFTID(s.nftClassID, collection.DefaultDepthLimit+1),
+			subject:    collection.NewNFTID(s.nftClassID, s.depthLimit+1),
 			target:     collection.NewNFTID(s.nftClassID, s.numNFTs+1),
 			err:        collection.ErrTokenNotOwnedBy,
 		},

--- a/x/collection/keeper/param.go
+++ b/x/collection/keeper/param.go
@@ -20,7 +20,7 @@ func (k Keeper) GetParams(ctx sdk.Context) collection.Params {
 	return params
 }
 
-func (k Keeper) setParams(ctx sdk.Context, params collection.Params) {
+func (k Keeper) SetParams(ctx sdk.Context, params collection.Params) {
 	store := ctx.KVStore(k.storeKey)
 	key := paramsKey
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would change the default value of `DepthLimit` and `WidthLimit` of x/collection, which constrains the size of hierarchies of composable nfts on x/collection.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Business requirement.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
