### PR TITLE
fix: sort removed urls in x/foundation Msg/UpdateParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 ### Bug Fixes
+* (x/foundation) [#943](https://github.com/line/lbm-sdk/pull/943) Sort removed urls in x/foundation Msg/UpdateParams
 
 ### Breaking Changes
 

--- a/x/foundation/keeper/params.go
+++ b/x/foundation/keeper/params.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"sort"
+
 	sdk "github.com/line/lbm-sdk/types"
 	sdkerrors "github.com/line/lbm-sdk/types/errors"
 
@@ -39,13 +41,17 @@ func (k Keeper) UpdateParams(ctx sdk.Context, params foundation.Params) error {
 	}
 
 	// clean up relevant authorizations
+	// sort it for the determinism (#)
+	urlRemovedSorted := make([]string, 0, len(urlRemoved))
 	for url, removed := range urlRemoved {
-		url := url
-
 		if !removed {
 			continue
 		}
+		urlRemovedSorted = append(urlRemovedSorted, url)
+	}
+	sort.Strings(urlRemovedSorted)
 
+	for _, url := range urlRemovedSorted {
 		var grantees []sdk.AccAddress
 		k.iterateAuthorizations(ctx, func(grantee sdk.AccAddress, authorization foundation.Authorization) (stop bool) {
 			if authorization.MsgTypeURL() == url {

--- a/x/foundation/keeper/params.go
+++ b/x/foundation/keeper/params.go
@@ -41,7 +41,7 @@ func (k Keeper) UpdateParams(ctx sdk.Context, params foundation.Params) error {
 	}
 
 	// clean up relevant authorizations
-	// sort it for the determinism (#)
+	// sort it for the determinism (line/lbm-sdk#943)
 	urlRemovedSorted := make([]string, 0, len(urlRemoved))
 	for url, removed := range urlRemoved {
 		if !removed {

--- a/x/foundation/keeper/params.go
+++ b/x/foundation/keeper/params.go
@@ -52,6 +52,8 @@ func (k Keeper) UpdateParams(ctx sdk.Context, params foundation.Params) error {
 	sort.Strings(urlRemovedSorted)
 
 	for _, url := range urlRemovedSorted {
+		url := url
+
 		var grantees []sdk.AccAddress
 		k.iterateAuthorizations(ctx, func(grantee sdk.AccAddress, authorization foundation.Authorization) (stop bool) {
 			if authorization.MsgTypeURL() == url {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would fix nondeterministic execution in x/foundation Msg/UpdateParams.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
10 Msg/UpdateParams tests in row, on the network with 8 nodes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
