### PR TITLE
chore: address generation of the empty coins in x/foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#912](https://github.com/line/lbm-sdk/pull/912) Introduce censorship into x/foundation
 * (x/foundation) [\#933](https://github.com/line/lbm-sdk/pull/933) Clean up x/foundation apis
 * (x/collection) [\#938](https://github.com/line/lbm-sdk/pull/938) Add progress log into x/collection import-genesis
+* (x/foundation) [\#952](https://github.com/line/lbm-sdk/pull/952) Address generation of the empty coins in x/foundation
 
 ### Bug Fixes
 * (swagger) [\#898](https://github.com/line/lbm-sdk/pull/898) fix a bug not added `lbm.tx.v1beta1.Service/GetBlockWithTxs` in swagger

--- a/client/grpc/tmservice/service_test.go
+++ b/client/grpc/tmservice/service_test.go
@@ -152,7 +152,7 @@ func (s IntegrationTestSuite) TestQueryBlockResultsByHeight() {
 	s.Require().Equal(0, len(txResult))
 
 	beginBlock := blockResultsRes.GetResBeginBlock()
-	s.Require().Equal(11, len(beginBlock.Events)) // coinbase event (6) + transfer mintModule to feeCollectorName(5)
+	s.Require().Equal(7, len(beginBlock.Events)) // coinbase event (6) + transfer mintModule to feeCollectorName(5) - foundation abci (4)
 
 	endBlock := blockResultsRes.GetResEndBlock()
 	s.Require().Equal(0, len(endBlock.Events))

--- a/x/foundation/keeper/internal/treasury.go
+++ b/x/foundation/keeper/internal/treasury.go
@@ -9,11 +9,17 @@ import (
 func (k Keeper) CollectFoundationTax(ctx sdk.Context) error {
 	feeCollector := k.authKeeper.GetModuleAccount(ctx, k.feeCollectorName).GetAddress()
 	feesCollectedInt := k.bankKeeper.GetAllBalances(ctx, feeCollector)
+	if feesCollectedInt.Empty() {
+		return nil
+	}
 	feesCollected := sdk.NewDecCoinsFromCoins(feesCollectedInt...)
 
 	// calculate the tax
 	taxRatio := k.GetFoundationTax(ctx)
 	tax, _ := feesCollected.MulDecTruncate(taxRatio).TruncateDecimal()
+	if tax.Empty() {
+		return nil
+	}
 
 	// collect the tax
 	if err := k.FundTreasury(ctx, feeCollector, tax); err != nil {

--- a/x/foundation/keeper/internal/treasury_test.go
+++ b/x/foundation/keeper/internal/treasury_test.go
@@ -7,29 +7,52 @@ import (
 )
 
 func (s *KeeperTestSuite) TestCollectFoundationTax() {
+	ctx, _ := s.ctx.CacheContext()
+
+	// empty fee collector first
+	// send the fee to the stranger
+	// and get it back later if the test case requires
+	collector := authtypes.NewModuleAddress(authtypes.FeeCollectorName)
+	fees := s.bankKeeper.GetAllBalances(ctx, collector)
+	s.bankKeeper.SendCoinsFromModuleToAccount(ctx, authtypes.FeeCollectorName, s.stranger, fees)
+
 	for name, tc := range map[string]struct {
+		fee      sdk.Int
 		taxRatio sdk.Dec
 		tax      sdk.Int
 		valid    bool
 	}{
 		"common": {
+			fee:      fees[0].Amount,
 			taxRatio: sdk.MustNewDecFromStr("0.123456789"),
 			tax:      sdk.NewInt(121932631),
 			valid:    true,
 		},
+		"zero fee": {
+			fee:      sdk.ZeroInt(),
+			taxRatio: sdk.MustNewDecFromStr("0.123456789"),
+			tax:      sdk.ZeroInt(),
+			valid:    true,
+		},
 		"zero ratio": {
+			fee:      fees[0].Amount,
 			taxRatio: sdk.ZeroDec(),
 			tax:      sdk.ZeroInt(),
 			valid:    true,
 		},
 		"send fails": {
+			fee:      fees[0].Amount,
 			taxRatio: sdk.MustNewDecFromStr("1.00000001"),
 			tax:      sdk.NewInt(987654330),
 		},
 	} {
 		s.Run(name, func() {
-			ctx, _ := s.ctx.CacheContext()
+			ctx, _ := ctx.CacheContext()
 
+			// set fee
+			s.bankKeeper.SendCoinsFromAccountToModule(ctx, s.stranger, authtypes.FeeCollectorName, sdk.NewCoins(sdk.NewCoin(fees[0].Denom, tc.fee)))
+
+			// set tax ratio
 			s.impl.SetParams(ctx, foundation.Params{
 				FoundationTax: tc.taxRatio,
 			})
@@ -38,7 +61,7 @@ func (s *KeeperTestSuite) TestCollectFoundationTax() {
 			s.Require().Equal(1, len(before))
 			s.Require().Equal(sdk.NewDecFromInt(s.balance), before[0].Amount)
 
-			tax := sdk.NewDecFromInt(s.balance).MulTruncate(tc.taxRatio).TruncateInt()
+			tax := sdk.NewDecFromInt(tc.fee).MulTruncate(tc.taxRatio).TruncateInt()
 			// ensure the behavior does not change
 			s.Require().Equal(tc.tax, tax)
 

--- a/x/foundation/keeper/internal/treasury_test.go
+++ b/x/foundation/keeper/internal/treasury_test.go
@@ -6,6 +6,57 @@ import (
 	"github.com/line/lbm-sdk/x/foundation"
 )
 
+func (s *KeeperTestSuite) TestCollectFoundationTax() {
+	for name, tc := range map[string]struct {
+		taxRatio sdk.Dec
+		tax      sdk.Int
+		valid    bool
+	}{
+		"common": {
+			taxRatio: sdk.MustNewDecFromStr("0.123456789"),
+			tax:      sdk.NewInt(121932631),
+			valid:    true,
+		},
+		"zero ratio": {
+			taxRatio: sdk.ZeroDec(),
+			tax:      sdk.ZeroInt(),
+			valid:    true,
+		},
+		"send fails": {
+			taxRatio: sdk.MustNewDecFromStr("1.00000001"),
+			tax:      sdk.NewInt(987654330),
+		},
+	} {
+		s.Run(name, func() {
+			ctx, _ := s.ctx.CacheContext()
+
+			s.impl.SetParams(ctx, foundation.Params{
+				FoundationTax: tc.taxRatio,
+			})
+
+			before := s.impl.GetTreasury(ctx)
+			s.Require().Equal(1, len(before))
+			s.Require().Equal(sdk.NewDecFromInt(s.balance), before[0].Amount)
+
+			tax := sdk.NewDecFromInt(s.balance).MulTruncate(tc.taxRatio).TruncateInt()
+			// ensure the behavior does not change
+			s.Require().Equal(tc.tax, tax)
+
+			err := s.impl.CollectFoundationTax(ctx)
+			if !tc.valid {
+				s.Require().Error(err)
+				return
+			}
+			s.Require().NoError(err)
+
+			expectedAfter := s.balance.Add(tax)
+			after := s.impl.GetTreasury(ctx)
+			s.Require().Equal(1, len(after))
+			s.Require().Equal(sdk.NewDecFromInt(expectedAfter), after[0].Amount)
+		})
+	}
+}
+
 func (s *KeeperTestSuite) TestFundTreasury() {
 	testCases := map[string]struct {
 		amount sdk.Int


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would check the generation of empty coins in x/foundation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
