### PR TITLE
fix: allow zero amount of coin in x/collection Query/Balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#922](https://github.com/line/lbm-sdk/pull/922) Propagate events in x/foundation through sdk.Results
 * (x/foundation) [\#946](https://github.com/line/lbm-sdk/pull/946) Fix broken x/foundation invariant on treasury
 * (x/foundation) [\#947](https://github.com/line/lbm-sdk/pull/947) Unpack proposals in x/foundation import-genesis
+* (x/collection) [\#953](https://github.com/line/lbm-sdk/pull/953) Allow zero amount of coin in x/collection Query/Balance
 
 ### Removed
 

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -51,7 +51,10 @@ func (s queryServer) Balance(c context.Context, req *collection.QueryBalanceRequ
 
 	ctx := sdk.UnwrapSDKContext(c)
 	balance := s.keeper.GetBalance(ctx, req.ContractId, addr, req.TokenId)
-	coin := collection.NewCoin(req.TokenId, balance)
+	coin := collection.Coin{
+		TokenId: req.TokenId,
+		Amount:  balance,
+	}
 
 	return &collection.QueryBalanceResponse{Balance: coin}, nil
 }

--- a/x/collection/keeper/grpc_query_test.go
+++ b/x/collection/keeper/grpc_query_test.go
@@ -27,7 +27,23 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 			tokenID:    tokenID,
 			valid:      true,
 			postTest: func(res *collection.QueryBalanceResponse) {
-				expected := collection.NewCoin(tokenID, s.balance)
+				expected := collection.Coin{
+					TokenId: tokenID,
+					Amount: s.balance,
+				}
+				s.Require().Equal(expected, res.Balance)
+			},
+		},
+		"valid request with zero amount": {
+			contractID: s.contractID,
+			address:    s.vendor,
+			tokenID:    "deadbeefdeadbeef",
+			valid:      true,
+			postTest: func(res *collection.QueryBalanceResponse) {
+				expected := collection.Coin{
+					TokenId: "deadbeefdeadbeef",
+					Amount: sdk.ZeroInt(),
+				}
 				s.Require().Equal(expected, res.Balance)
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would allow zero amount of coin in x/collection Query/Balance.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
