### PR TITLE
fix: remove duplicated events in x/collection Msg/Modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#922](https://github.com/line/lbm-sdk/pull/922) Propagate events in x/foundation through sdk.Results
 * (x/foundation) [\#946](https://github.com/line/lbm-sdk/pull/946) Fix broken x/foundation invariant on treasury
 * (x/foundation) [\#947](https://github.com/line/lbm-sdk/pull/947) Unpack proposals in x/foundation import-genesis
+* (x/collection) [\#954](https://github.com/line/lbm-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
 
 ### Removed
 

--- a/x/collection/keeper/supply.go
+++ b/x/collection/keeper/supply.go
@@ -339,14 +339,6 @@ func (k Keeper) ModifyContract(ctx sdk.Context, contractID string, operator sdk.
 
 	k.setContract(ctx, *contract)
 
-	event := collection.EventModifiedContract{
-		ContractId: contractID,
-		Operator:   operator.String(),
-		Changes:    changes,
-	}
-	if err := ctx.EventManager().EmitTypedEvent(&event); err != nil {
-		panic(err)
-	}
 	return nil
 }
 
@@ -380,15 +372,6 @@ func (k Keeper) ModifyTokenClass(ctx sdk.Context, contractID string, classID str
 
 	k.setTokenClass(ctx, contractID, class)
 
-	event := collection.EventModifiedTokenClass{
-		ContractId: contractID,
-		TokenType:  class.GetId(),
-		Operator:   operator.String(),
-		Changes:    changes,
-	}
-	if err := ctx.EventManager().EmitTypedEvent(&event); err != nil {
-		panic(err)
-	}
 	return nil
 }
 
@@ -413,15 +396,6 @@ func (k Keeper) ModifyNFT(ctx sdk.Context, contractID string, tokenID string, op
 
 	k.setNFT(ctx, contractID, *token)
 
-	event := collection.EventModifiedNFT{
-		ContractId: contractID,
-		TokenId:    tokenID,
-		Operator:   operator.String(),
-		Changes:    changes,
-	}
-	if err := ctx.EventManager().EmitTypedEvent(&event); err != nil {
-		panic(err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would remove duplicated events in x/collection Msg/Modify.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
