### PR TITLE
fix: return nil where the parent not exists in x/collection Query/Parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#922](https://github.com/line/lbm-sdk/pull/922) Propagate events in x/foundation through sdk.Results
 * (x/foundation) [\#946](https://github.com/line/lbm-sdk/pull/946) Fix broken x/foundation invariant on treasury
 * (x/foundation) [\#947](https://github.com/line/lbm-sdk/pull/947) Unpack proposals in x/foundation import-genesis
+* (x/collection) [\#955](https://github.com/line/lbm-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
 
 ### Removed
 

--- a/docs/core/proto-docs.md
+++ b/docs/core/proto-docs.md
@@ -10461,7 +10461,7 @@ QueryParentResponse is the response type for the Query/Parent RPC method.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `parent` | [NFT](#lbm.collection.v1.NFT) |  | parent is the information of the parent token. if there is no parent for the token, it would return nil. |
+| `parent` | [NFT](#lbm.collection.v1.NFT) |  | parent is the information of the parent token. |
 
 
 

--- a/proto/lbm/collection/v1/query.proto
+++ b/proto/lbm/collection/v1/query.proto
@@ -310,7 +310,6 @@ message QueryParentRequest {
 // QueryParentResponse is the response type for the Query/Parent RPC method.
 message QueryParentResponse {
   // parent is the information of the parent token.
-  // if there is no parent for the token, it would return nil.
   NFT parent = 1 [(gogoproto.nullable) = false];
 }
 

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -427,7 +427,7 @@ func (s queryServer) Parent(c context.Context, req *collection.QueryParentReques
 
 	parent, err := s.keeper.GetParent(ctx, req.ContractId, req.TokenId)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 
 	token, err := s.keeper.GetNFT(ctx, req.ContractId, *parent)

--- a/x/collection/keeper/grpc_query_test.go
+++ b/x/collection/keeper/grpc_query_test.go
@@ -704,7 +704,16 @@ func (s *KeeperTestSuite) TestQueryParent() {
 			tokenID:    tokenID,
 			valid:      true,
 			postTest: func(res *collection.QueryParentResponse) {
+				s.Require().NotNil(res)
 				s.Require().Equal(collection.NewNFTID(s.nftClassID, 1), res.Parent.TokenId)
+			},
+		},
+		"valid request with no parent": {
+			contractID: s.contractID,
+			tokenID:    collection.NewNFTID(s.nftClassID, 1),
+			valid:      true,
+			postTest: func(res *collection.QueryParentResponse) {
+				s.Require().Nil(res)
 			},
 		},
 		"invalid contract id": {
@@ -716,10 +725,6 @@ func (s *KeeperTestSuite) TestQueryParent() {
 		"no such a token": {
 			contractID: s.contractID,
 			tokenID:    collection.NewNFTID("deadbeef", 1),
-		},
-		"no parent": {
-			contractID: s.contractID,
-			tokenID:    collection.NewNFTID(s.nftClassID, 1),
 		},
 	}
 
@@ -735,7 +740,6 @@ func (s *KeeperTestSuite) TestQueryParent() {
 				return
 			}
 			s.Require().NoError(err)
-			s.Require().NotNil(res)
 			tc.postTest(res)
 		})
 	}

--- a/x/collection/query.pb.go
+++ b/x/collection/query.pb.go
@@ -1388,7 +1388,6 @@ func (m *QueryParentRequest) GetTokenId() string {
 // QueryParentResponse is the response type for the Query/Parent RPC method.
 type QueryParentResponse struct {
 	// parent is the information of the parent token.
-	// if there is no parent for the token, it would return nil.
 	Parent NFT `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent"`
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would make Query/Parent not to return an error even if the parent does not exist.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Daphne compatibility.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
