### PR TITLE
fix: replace query errors on the original modules into gRPC ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Breaking Changes
 * (proto) [\#923](https://github.com/line/lbm-sdk/pull/923) deprecate broadcast mode `block`
+* (x/collection,token) [\#956](https://github.com/line/lbm-sdk/pull/956) Replace query errors on the original modules into gRPC ones
 
 ### Build, CI
 * (ci, build) [\#901](https://github.com/line/lbm-sdk/pull/901) Update release pipeline to match non-wasm env

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -384,7 +384,7 @@ func NewSimApp(
 		upgrade.NewAppModule(app.UpgradeKeeper),
 		evidence.NewAppModule(app.EvidenceKeeper),
 		params.NewAppModule(app.ParamsKeeper),
-		tokenmodule.NewAppModule(appCodec, app.TokenKeeper),
+		tokenmodule.NewAppModule(appCodec, app.TokenKeeper, app.AccountKeeper),
 		collectionmodule.NewAppModule(appCodec, app.CollectionKeeper, app.AccountKeeper),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 	)

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -385,7 +385,7 @@ func NewSimApp(
 		evidence.NewAppModule(app.EvidenceKeeper),
 		params.NewAppModule(app.ParamsKeeper),
 		tokenmodule.NewAppModule(appCodec, app.TokenKeeper),
-		collectionmodule.NewAppModule(appCodec, app.CollectionKeeper),
+		collectionmodule.NewAppModule(appCodec, app.CollectionKeeper, app.AccountKeeper),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 	)
 

--- a/x/collection/client/testutil/query.go
+++ b/x/collection/client/testutil/query.go
@@ -326,17 +326,17 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTSupply() {
 		"valid query": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 			},
 			true,
 			&collection.QueryNFTSupplyResponse{
-				Supply: s.balance.Mul(sdk.NewInt(4)),
+				Supply: sdk.NewInt(24),
 			},
 		},
 		"extra args": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 				"extra",
 			},
 			false,
@@ -352,7 +352,7 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTSupply() {
 		"invalid contract id": {
 			[]string{
 				"",
-				s.ftClassID,
+				s.nftClassID,
 			},
 			false,
 			nil,
@@ -401,17 +401,17 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTMinted() {
 		"valid query": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 			},
 			true,
 			&collection.QueryNFTMintedResponse{
-				Minted: s.balance.Mul(sdk.NewInt(5)),
+				Minted: sdk.NewInt(24),
 			},
 		},
 		"extra args": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 				"extra",
 			},
 			false,
@@ -427,7 +427,7 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTMinted() {
 		"invalid contract id": {
 			[]string{
 				"",
-				s.ftClassID,
+				s.nftClassID,
 			},
 			false,
 			nil,
@@ -476,17 +476,17 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTBurnt() {
 		"valid query": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 			},
 			true,
 			&collection.QueryNFTBurntResponse{
-				Burnt: s.balance,
+				Burnt: sdk.ZeroInt(),
 			},
 		},
 		"extra args": {
 			[]string{
 				s.contractID,
-				s.ftClassID,
+				s.nftClassID,
 				"extra",
 			},
 			false,
@@ -502,7 +502,7 @@ func (s *IntegrationTestSuite) TestNewQueryCmdNFTBurnt() {
 		"invalid contract id": {
 			[]string{
 				"",
-				s.ftClassID,
+				s.nftClassID,
 			},
 			false,
 			nil,

--- a/x/collection/expected_keepers.go
+++ b/x/collection/expected_keepers.go
@@ -10,4 +10,8 @@ type (
 		NewID(ctx sdk.Context) string
 		HasID(ctx sdk.Context, id string) bool
 	}
+
+	AuthKeeper interface {
+		HasAccount(sdk.Context, sdk.AccAddress) bool
+	}
 )

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -30,7 +30,7 @@ func NewQueryServer(keeper Keeper, authKeeper collection.AuthKeeper) collection.
 	}
 }
 
-func (s queryServer) validateAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) error {
+func (s queryServer) validateExistenceOfAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) error {
 	if !s.authKeeper.HasAccount(ctx, addr) {
 		return status.Error(codes.NotFound, sdkerrors.ErrUnknownAddress.Wrap(addr.String()).Error())
 	}
@@ -38,7 +38,7 @@ func (s queryServer) validateAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) e
 	return nil
 }
 
-func (s queryServer) validateCollectionGRPC(ctx sdk.Context, id string) error {
+func (s queryServer) validateExistenceOfCollectionGRPC(ctx sdk.Context, id string) error {
 	if _, err := s.keeper.GetContract(ctx, id); err != nil {
 		return status.Error(codes.NotFound, err.Error())
 	}
@@ -46,7 +46,7 @@ func (s queryServer) validateCollectionGRPC(ctx sdk.Context, id string) error {
 	return nil
 }
 
-func (s queryServer) validateFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
+func (s queryServer) validateExistenceOfFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
 	class, err := s.keeper.GetTokenClass(ctx, contractID, classID)
 	if err != nil {
 		return status.Error(codes.NotFound, err.Error())
@@ -59,7 +59,7 @@ func (s queryServer) validateFTClassGRPC(ctx sdk.Context, contractID, classID st
 	return nil
 }
 
-func (s queryServer) validateNFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
+func (s queryServer) validateExistenceOfNFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
 	class, err := s.keeper.GetTokenClass(ctx, contractID, classID)
 	if err != nil {
 		return status.Error(codes.NotFound, err.Error())
@@ -95,11 +95,11 @@ func (s queryServer) Balance(c context.Context, req *collection.QueryBalanceRequ
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, addr); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, addr); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -167,11 +167,11 @@ func (s queryServer) FTSupply(c context.Context, req *collection.QueryFTSupplyRe
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -197,11 +197,11 @@ func (s queryServer) FTMinted(c context.Context, req *collection.QueryFTMintedRe
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -227,11 +227,11 @@ func (s queryServer) FTBurnt(c context.Context, req *collection.QueryFTBurntRequ
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -256,11 +256,11 @@ func (s queryServer) NFTSupply(c context.Context, req *collection.QueryNFTSupply
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -285,11 +285,11 @@ func (s queryServer) NFTMinted(c context.Context, req *collection.QueryNFTMinted
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -314,11 +314,11 @@ func (s queryServer) NFTBurnt(c context.Context, req *collection.QueryNFTBurntRe
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+	if err := s.validateExistenceOfNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
 		return nil, err
 	}
 
@@ -361,7 +361,7 @@ func (s queryServer) TokenClassTypeName(c context.Context, req *collection.Query
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -492,7 +492,7 @@ func (s queryServer) Root(c context.Context, req *collection.QueryRootRequest) (
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -524,7 +524,7 @@ func (s queryServer) Parent(c context.Context, req *collection.QueryParentReques
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -560,7 +560,7 @@ func (s queryServer) Children(c context.Context, req *collection.QueryChildrenRe
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -604,11 +604,11 @@ func (s queryServer) GranteeGrants(c context.Context, req *collection.QueryGrant
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, granteeAddr); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, granteeAddr); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -650,14 +650,14 @@ func (s queryServer) IsOperatorFor(c context.Context, req *collection.QueryIsOpe
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, operator); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, operator); err != nil {
 		return nil, err
 	}
-	if err := s.validateAccountGRPC(ctx, holder); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, holder); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateCollectionGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -46,6 +46,32 @@ func (s queryServer) validateCollectionGRPC(ctx sdk.Context, id string) error {
 	return nil
 }
 
+func (s queryServer) validateFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
+	class, err := s.keeper.GetTokenClass(ctx, contractID, classID)
+	if err != nil {
+		return status.Error(codes.NotFound, err.Error())
+	}
+
+	_, ok := class.(*collection.FTClass)
+	if !ok {
+		return status.Error(codes.NotFound, sdkerrors.ErrInvalidType.Wrapf("not a class of fungible token: %s", classID).Error())
+	}
+	return nil
+}
+
+func (s queryServer) validateNFTClassGRPC(ctx sdk.Context, contractID, classID string) error {
+	class, err := s.keeper.GetTokenClass(ctx, contractID, classID)
+	if err != nil {
+		return status.Error(codes.NotFound, err.Error())
+	}
+
+	_, ok := class.(*collection.NFTClass)
+	if !ok {
+		return status.Error(codes.NotFound, sdkerrors.ErrInvalidType.Wrapf("not a class of non-fungible token: %s", classID).Error())
+	}
+	return nil
+}
+
 var _ collection.QueryServer = queryServer{}
 
 // Balance queries the number of tokens of a given token id owned by the owner.
@@ -145,9 +171,10 @@ func (s queryServer) FTSupply(c context.Context, req *collection.QueryFTSupplyRe
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	supply := s.keeper.GetSupply(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTSupplyResponse{Supply: supply}, nil
@@ -174,9 +201,10 @@ func (s queryServer) FTMinted(c context.Context, req *collection.QueryFTMintedRe
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	minted := s.keeper.GetMinted(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTMintedResponse{Minted: minted}, nil
@@ -203,9 +231,10 @@ func (s queryServer) FTBurnt(c context.Context, req *collection.QueryFTBurntRequ
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	burnt := s.keeper.GetBurnt(ctx, req.ContractId, classID)
 
 	return &collection.QueryFTBurntResponse{Burnt: burnt}, nil
@@ -231,9 +260,10 @@ func (s queryServer) NFTSupply(c context.Context, req *collection.QueryNFTSupply
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	supply := s.keeper.GetSupply(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTSupplyResponse{Supply: supply}, nil
@@ -259,9 +289,10 @@ func (s queryServer) NFTMinted(c context.Context, req *collection.QueryNFTMinted
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	minted := s.keeper.GetMinted(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTMintedResponse{Minted: minted}, nil
@@ -287,9 +318,10 @@ func (s queryServer) NFTBurnt(c context.Context, req *collection.QueryNFTBurntRe
 		return nil, err
 	}
 
-	if _, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID); err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+	if err := s.validateNFTClassGRPC(ctx, req.ContractId, classID); err != nil {
+		return nil, err
 	}
+
 	burnt := s.keeper.GetBurnt(ctx, req.ContractId, classID)
 
 	return &collection.QueryNFTBurntResponse{Burnt: burnt}, nil

--- a/x/collection/keeper/grpc_query_test.go
+++ b/x/collection/keeper/grpc_query_test.go
@@ -29,7 +29,7 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 			postTest: func(res *collection.QueryBalanceResponse) {
 				expected := collection.Coin{
 					TokenId: tokenID,
-					Amount: s.balance,
+					Amount:  s.balance,
 				}
 				s.Require().Equal(expected, res.Balance)
 			},
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 			postTest: func(res *collection.QueryBalanceResponse) {
 				expected := collection.Coin{
 					TokenId: "deadbeefdeadbeef",
-					Amount: sdk.ZeroInt(),
+					Amount:  sdk.ZeroInt(),
 				}
 				s.Require().Equal(expected, res.Balance)
 			},

--- a/x/collection/keeper/grpc_query_test.go
+++ b/x/collection/keeper/grpc_query_test.go
@@ -36,12 +36,12 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 		},
 		"valid request with zero amount": {
 			contractID: s.contractID,
-			address:    s.vendor,
-			tokenID:    "deadbeefdeadbeef",
+			address:    s.stranger,
+			tokenID:    tokenID,
 			valid:      true,
 			postTest: func(res *collection.QueryBalanceResponse) {
 				expected := collection.Coin{
-					TokenId: "deadbeefdeadbeef",
+					TokenId: tokenID,
 					Amount:  sdk.ZeroInt(),
 				}
 				s.Require().Equal(expected, res.Balance)
@@ -55,9 +55,19 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 			contractID: s.contractID,
 			tokenID:    tokenID,
 		},
-		"valid token id": {
+		"invalid token id": {
 			contractID: s.contractID,
 			address:    s.vendor,
+		},
+		"address not found": {
+			contractID: s.contractID,
+			address:    sdk.AccAddress("notfound"),
+			tokenID:    tokenID,
+		},
+		"collection not found": {
+			contractID: "deadbeef",
+			address:    s.vendor,
+			tokenID:    tokenID,
 		},
 	}
 
@@ -166,9 +176,17 @@ func (s *KeeperTestSuite) TestQueryFTSupply() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
-		"no such a token": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
 			contractID: s.contractID,
 			tokenID:    collection.NewFTID("00bab10c"),
+		},
+		"not a class of ft": {
+			contractID: s.contractID,
+			tokenID:    collection.NewFTID(s.nftClassID),
 		},
 	}
 
@@ -216,9 +234,17 @@ func (s *KeeperTestSuite) TestQueryFTMinted() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
-		"no such a token": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
 			contractID: s.contractID,
 			tokenID:    collection.NewFTID("00bab10c"),
+		},
+		"not a class of ft": {
+			contractID: s.contractID,
+			tokenID:    collection.NewFTID(s.nftClassID),
 		},
 	}
 
@@ -266,9 +292,17 @@ func (s *KeeperTestSuite) TestQueryFTBurnt() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
-		"no such a token": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
 			contractID: s.contractID,
 			tokenID:    collection.NewFTID("00bab10c"),
+		},
+		"not a class of ft": {
+			contractID: s.contractID,
+			tokenID:    collection.NewFTID(s.nftClassID),
 		},
 	}
 
@@ -315,9 +349,17 @@ func (s *KeeperTestSuite) TestQueryNFTSupply() {
 		"invalid token type": {
 			contractID: s.contractID,
 		},
-		"no such a token type": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenType:  s.nftClassID,
+		},
+		"token type not found": {
 			contractID: s.contractID,
 			tokenType:  "deadbeef",
+		},
+		"not a class of nft": {
+			contractID: s.contractID,
+			tokenType:  s.ftClassID,
 		},
 	}
 
@@ -364,9 +406,17 @@ func (s *KeeperTestSuite) TestQueryNFTMinted() {
 		"invalid token type": {
 			contractID: s.contractID,
 		},
-		"no such a token type": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenType:  s.nftClassID,
+		},
+		"token type not found": {
 			contractID: s.contractID,
 			tokenType:  "deadbeef",
+		},
+		"not a class of nft": {
+			contractID: s.contractID,
+			tokenType:  s.ftClassID,
 		},
 	}
 
@@ -413,9 +463,17 @@ func (s *KeeperTestSuite) TestQueryNFTBurnt() {
 		"invalid token type": {
 			contractID: s.contractID,
 		},
-		"no such a token type": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenType:  s.nftClassID,
+		},
+		"token type not found": {
 			contractID: s.contractID,
 			tokenType:  "deadbeef",
+		},
+		"not a class of nft": {
+			contractID: s.contractID,
+			tokenType:  s.ftClassID,
 		},
 	}
 
@@ -502,7 +560,11 @@ func (s *KeeperTestSuite) TestQueryTokenClassTypeName() {
 		"invalid class id": {
 			contractID: s.contractID,
 		},
-		"no such a class": {
+		"collection not found": {
+			contractID: "deadbeef",
+			classID:    s.ftClassID,
+		},
+		"class not found": {
 			contractID: s.contractID,
 			classID:    "00bab10c",
 		},
@@ -552,7 +614,11 @@ func (s *KeeperTestSuite) TestQueryTokenType() {
 		"invalid token type": {
 			contractID: s.contractID,
 		},
-		"no such a token type": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenType:  s.nftClassID,
+		},
+		"token type not found": {
 			contractID: s.contractID,
 			tokenType:  "deadbeef",
 		},
@@ -679,7 +745,11 @@ func (s *KeeperTestSuite) TestQueryRoot() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
-		"no such a token": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
 			contractID: s.contractID,
 			tokenID:    collection.NewNFTID("deadbeef", 1),
 		},
@@ -738,7 +808,11 @@ func (s *KeeperTestSuite) TestQueryParent() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
-		"no such a token": {
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
 			contractID: s.contractID,
 			tokenID:    collection.NewNFTID("deadbeef", 1),
 		},
@@ -799,6 +873,14 @@ func (s *KeeperTestSuite) TestQueryChildren() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    tokenID,
+		},
+		"token not found": {
+			contractID: s.contractID,
+			tokenID:    collection.NewNFTID("deadbeef", 1),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -848,6 +930,14 @@ func (s *KeeperTestSuite) TestQueryGranteeGrants() {
 		},
 		"invalid grantee": {
 			contractID: s.contractID,
+		},
+		"collection not found": {
+			contractID: "deadbeef",
+			grantee:    s.vendor,
+		},
+		"grantee not found": {
+			contractID: s.contractID,
+			grantee:    sdk.AccAddress("notfound"),
 		},
 	}
 
@@ -901,6 +991,21 @@ func (s *KeeperTestSuite) TestQueryIsOperatorFor() {
 		"invalid holder": {
 			contractID: s.contractID,
 			operator:   s.operator,
+		},
+		"collection not found": {
+			contractID: "deadbeef",
+			operator:   s.operator,
+			holder:     s.vendor,
+		},
+		"operator not found": {
+			contractID: s.contractID,
+			operator:   sdk.AccAddress("notfound"),
+			holder:     s.customer,
+		},
+		"holder not found": {
+			contractID: s.contractID,
+			operator:   s.operator,
+			holder:     sdk.AccAddress("notfound"),
 		},
 	}
 

--- a/x/collection/keeper/keeper_test.go
+++ b/x/collection/keeper/keeper_test.go
@@ -64,7 +64,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.goCtx = sdk.WrapSDKContext(s.ctx)
 	s.keeper = app.CollectionKeeper
 
-	s.queryServer = keeper.NewQueryServer(s.keeper)
+	s.queryServer = keeper.NewQueryServer(s.keeper, app.AccountKeeper)
 	s.msgServer = keeper.NewMsgServer(s.keeper)
 
 	s.depthLimit = 4
@@ -81,6 +81,10 @@ func (s *KeeperTestSuite) SetupTest() {
 	}
 	for i, address := range createRandomAccounts(len(addresses)) {
 		*addresses[i] = address
+
+		// create account
+		acc := app.AccountKeeper.NewAccountWithAddress(s.ctx, address)
+		app.AccountKeeper.SetAccount(s.ctx, acc)
 	}
 
 	s.balance = sdk.NewInt(1000000)

--- a/x/collection/module/module.go
+++ b/x/collection/module/module.go
@@ -15,7 +15,6 @@ import (
 	sdk "github.com/line/lbm-sdk/types"
 	"github.com/line/lbm-sdk/types/module"
 	"github.com/line/lbm-sdk/x/collection"
-
 	"github.com/line/lbm-sdk/x/collection/client/cli"
 	"github.com/line/lbm-sdk/x/collection/keeper"
 )
@@ -79,13 +78,15 @@ func (b AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper     keeper.Keeper
+	authKeeper collection.AuthKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, authKeeper collection.AuthKeeper) AppModule {
 	return AppModule{
-		keeper: keeper,
+		keeper:     keeper,
+		authKeeper: authKeeper,
 	}
 }
 
@@ -107,7 +108,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	collection.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServer(am.keeper))
-	collection.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper))
+	collection.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper, am.authKeeper))
 
 	// m := keeper.NewMigrator(am.keeper)
 	// migrations := map[uint64]func(sdk.Context) error{}

--- a/x/token/expected_keepers.go
+++ b/x/token/expected_keepers.go
@@ -13,4 +13,8 @@ type (
 		InitGenesis(ctx sdk.Context, data *ClassGenesisState)
 		ExportGenesis(ctx sdk.Context) *ClassGenesisState
 	}
+
+	AuthKeeper interface {
+		HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool
+	}
 )

--- a/x/token/keeper/grpc_query.go
+++ b/x/token/keeper/grpc_query.go
@@ -29,7 +29,7 @@ func NewQueryServer(keeper Keeper, authKeeper token.AuthKeeper) token.QueryServe
 
 var _ token.QueryServer = queryServer{}
 
-func (s queryServer) validateAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) error {
+func (s queryServer) validateExistenceOfAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) error {
 	if !s.authKeeper.HasAccount(ctx, addr) {
 		return status.Error(codes.NotFound, sdkerrors.ErrUnknownAddress.Wrap(addr.String()).Error())
 	}
@@ -37,7 +37,7 @@ func (s queryServer) validateAccountGRPC(ctx sdk.Context, addr sdk.AccAddress) e
 	return nil
 }
 
-func (s queryServer) validateClassGRPC(ctx sdk.Context, id string) error {
+func (s queryServer) validateExistenceOfClassGRPC(ctx sdk.Context, id string) error {
 	if _, err := s.keeper.GetClass(ctx, id); err != nil {
 		return status.Error(codes.NotFound, err.Error())
 	}
@@ -61,7 +61,7 @@ func (s queryServer) Balance(c context.Context, req *token.QueryBalanceRequest) 
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, addr); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, addr); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +82,7 @@ func (s queryServer) Supply(c context.Context, req *token.QuerySupplyRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateClassGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfClassGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (s queryServer) Minted(c context.Context, req *token.QueryMintedRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateClassGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfClassGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -124,7 +124,7 @@ func (s queryServer) Burnt(c context.Context, req *token.QueryBurntRequest) (*to
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateClassGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfClassGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -167,11 +167,11 @@ func (s queryServer) GranteeGrants(c context.Context, req *token.QueryGranteeGra
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, grantee); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, grantee); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateClassGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfClassGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 
@@ -212,14 +212,14 @@ func (s queryServer) IsOperatorFor(c context.Context, req *token.QueryIsOperator
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if err := s.validateAccountGRPC(ctx, operator); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, operator); err != nil {
 		return nil, err
 	}
-	if err := s.validateAccountGRPC(ctx, holder); err != nil {
+	if err := s.validateExistenceOfAccountGRPC(ctx, holder); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateClassGRPC(ctx, req.ContractId); err != nil {
+	if err := s.validateExistenceOfClassGRPC(ctx, req.ContractId); err != nil {
 		return nil, err
 	}
 

--- a/x/token/keeper/grpc_query_test.go
+++ b/x/token/keeper/grpc_query_test.go
@@ -31,6 +31,10 @@ func (s *KeeperTestSuite) TestQueryBalance() {
 		"invalid address": {
 			contractID: s.contractID,
 		},
+		"address not found": {
+			contractID: s.contractID,
+			address:    sdk.AccAddress("notfound"),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -237,6 +241,14 @@ func (s *KeeperTestSuite) TestQueryGranteeGrants() {
 		"invalid grantee": {
 			contractID: s.contractID,
 		},
+		"class not found": {
+			contractID: "fee1dead",
+			grantee:    s.vendor,
+		},
+		"grantee not found": {
+			contractID: s.contractID,
+			grantee:    sdk.AccAddress("notfound"),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -289,6 +301,21 @@ func (s *KeeperTestSuite) TestQueryIsOperatorFor() {
 		"invalid holder": {
 			contractID: s.contractID,
 			operator:   s.operator,
+		},
+		"class not found": {
+			contractID: "fee1dead",
+			operator:   s.operator,
+			holder:     s.vendor,
+		},
+		"operator not found": {
+			contractID: s.contractID,
+			operator:   sdk.AccAddress("notfound"),
+			holder:     s.customer,
+		},
+		"holder not found": {
+			contractID: s.contractID,
+			operator:   s.operator,
+			holder:     sdk.AccAddress("notfound"),
 		},
 	}
 

--- a/x/token/keeper/keeper_test.go
+++ b/x/token/keeper/keeper_test.go
@@ -57,7 +57,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.goCtx = sdk.WrapSDKContext(s.ctx)
 	s.keeper = app.TokenKeeper
 
-	s.queryServer = keeper.NewQueryServer(s.keeper)
+	s.queryServer = keeper.NewQueryServer(s.keeper, app.AccountKeeper)
 	s.msgServer = keeper.NewMsgServer(s.keeper)
 
 	addresses := []*sdk.AccAddress{
@@ -68,6 +68,9 @@ func (s *KeeperTestSuite) SetupTest() {
 	}
 	for i, address := range createRandomAccounts(len(addresses)) {
 		*addresses[i] = address
+
+		acc := app.AccountKeeper.NewAccountWithAddress(s.ctx, address)
+		app.AccountKeeper.SetAccount(s.ctx, acc)
 	}
 
 	s.balance = sdk.NewInt(1000)

--- a/x/token/module/module.go
+++ b/x/token/module/module.go
@@ -78,13 +78,15 @@ func (b AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper     keeper.Keeper
+	authKeeper token.AuthKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, authKeeper token.AuthKeeper) AppModule {
 	return AppModule{
-		keeper: keeper,
+		keeper:     keeper,
+		authKeeper: authKeeper,
 	}
 }
 
@@ -106,7 +108,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	token.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServer(am.keeper))
-	token.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper))
+	token.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper, am.authKeeper))
 
 	// m := keeper.NewMigrator(am.keeper)
 	// migrations := map[uint64]func(sdk.Context) error{}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would replace previous errors on queries into gRPC ones.

"Almost" all gRPC queries on x/token and x/collection would return NotFound, where
- The relevant address does not exist
- The relevant contract does not exist
- The relevant token does not exist
- The relevant token class does not exist

CAUTION: this will break the compatibility with Daphne on queries.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our client wants the errors on gRPC interface to have the right error code on `NotFound`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
