### PR TITLE
fix: fix default next class ids of x/collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#954](https://github.com/line/lbm-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
 * (x/collection) [\#955](https://github.com/line/lbm-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
 * (x/collection) [\#959](https://github.com/line/lbm-sdk/pull/959) Revert #955 and add Query/HasParent into x/collection
-* (x/collection) [\#961](https://github.com/line/lbm-sdk/pull/961) Do not loop enum in x/collection
+* (x/collection) [\#960](https://github.com/line/lbm-sdk/pull/960) Fix default next class ids of x/collection
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#954](https://github.com/line/lbm-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
 * (x/collection) [\#955](https://github.com/line/lbm-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
 * (x/collection) [\#959](https://github.com/line/lbm-sdk/pull/959) Revert #955 and add Query/HasParent into x/collection
+* (x/collection) [\#961](https://github.com/line/lbm-sdk/pull/961) Do not loop enum in x/collection
 
 ### Removed
 

--- a/x/collection/collection.go
+++ b/x/collection/collection.go
@@ -28,8 +28,8 @@ func (x LegacyPermission) String() string {
 func DefaultNextClassIDs(contractID string) NextClassIDs {
 	return NextClassIDs{
 		ContractId:  contractID,
-		Fungible:    sdk.NewUint(0),
-		NonFungible: sdk.NewUint(1 << 28), // "10000000"
+		Fungible:    sdk.NewUint(1),
+		NonFungible: sdk.NewUint(1 << 28).Incr(), // "10000000 + 1"
 	}
 }
 

--- a/x/collection/collection_test.go
+++ b/x/collection/collection_test.go
@@ -171,3 +171,14 @@ func TestParseCoins(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultNextClassIDs(t *testing.T) {
+	contractID := "deadbeef"
+	require.Equal(t, collection.NextClassIDs{
+		ContractId:  contractID,
+		Fungible:    sdk.NewUint(1),
+		NonFungible: sdk.NewUint(1 << 28).Incr(), // "10000000 + 1"
+	},
+		collection.DefaultNextClassIDs(contractID),
+	)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would fix the default class ids of x/collection. It would be same as Daphne's.
- next ft class id: "00000000" -> "00000001"
- next nft class id: "10000000" -> "10000001"

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
