### PR TITLE
chore: provide specific error messages on x/collection queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#938](https://github.com/line/lbm-sdk/pull/938) Add progress log into x/collection import-genesis
 * (x/foundation) [\#952](https://github.com/line/lbm-sdk/pull/952) Address generation of the empty coins in x/foundation
 * (x/collection,token,foundation) [\#963](https://github.com/line/lbm-sdk/pull/963) Check event determinism on original modules
+* (x/collection) [\#965](https://github.com/line/lbm-sdk/pull/965) Provide specific error messages on x/collection queries
 
 ### Bug Fixes
 * (swagger) [\#898](https://github.com/line/lbm-sdk/pull/898) fix a bug not added `lbm.tx.v1beta1.Service/GetBlockWithTxs` in swagger

--- a/x/collection/keeper/grpc_query.go
+++ b/x/collection/keeper/grpc_query.go
@@ -379,6 +379,11 @@ func (s queryServer) TokenType(c context.Context, req *collection.QueryTokenType
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
+		return nil, err
+	}
+
 	class, err := s.keeper.GetTokenClass(ctx, req.ContractId, classID)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -454,6 +459,11 @@ func (s queryServer) Token(c context.Context, req *collection.QueryTokenRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+
+	if err := s.validateExistenceOfCollectionGRPC(ctx, req.ContractId); err != nil {
+		return nil, err
+	}
+
 	legacyToken, err := s.getToken(ctx, req.ContractId, req.TokenId)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())

--- a/x/collection/keeper/grpc_query_test.go
+++ b/x/collection/keeper/grpc_query_test.go
@@ -681,6 +681,10 @@ func (s *KeeperTestSuite) TestQueryToken() {
 		"invalid token id": {
 			contractID: s.contractID,
 		},
+		"collection not found": {
+			contractID: "deadbeef",
+			tokenID:    ftTokenID,
+		},
 		"no such a fungible token": {
 			contractID: s.contractID,
 			tokenID:    collection.NewFTID("00bab10c"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would make the following queries provide more specific error messages. The error code does not change.
- Query/TokenType
- Query/Token

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reported by @loin3.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
