### PR TITLE
feat: add abbreviated vote option to x/foundation vote cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (ostracon) [\#1057](https://github.com/Finschia/finschia-sdk/pull/1057) Bump up Ostracon from to v1.1.1
 * (docs) [\#1120](https://github.com/Finschia/finschia-sdk/pull/1120) Update links in x/foundation README.md
 * (feat) [\#1121](https://github.com/Finschia/finschia-sdk/pull/1121) Add update-censorship cmd to x/foundation cli
+* (feat) [\#1127](https://github.com/Finschia/finschia-sdk/pull/1127) Add abbreviated vote option to x/foundation vote cli
 
 ### Bug Fixes
 * (ledger) [\#1040](https://github.com/Finschia/finschia-sdk/pull/1040) fix a bug(unable to connect nano S plus ledger on ubuntu)

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -92,6 +92,16 @@ func execFromString(execStr string) foundation.Exec {
 	return exec
 }
 
+func normalizeVoteOption(option string) string {
+	prefix := getEnumPrefix(foundation.VoteOption_name[0])
+	candidate := strings.ToUpper(prefix + option)
+	if _, ok := foundation.VoteOption_value[candidate]; ok {
+		return candidate
+	}
+
+	return option
+}
+
 func normalizeCensorshipAuthority(option string) string {
 	prefix := getEnumPrefix(foundation.CensorshipAuthority_name[0])
 	candidate := strings.ToUpper(prefix + option)
@@ -485,11 +495,11 @@ Parameters:
     proposal-id: unique ID of the proposal
     voter: voter account addresses.
     vote-option: choice of the voter(s)
-        VOTE_OPTION_UNSPECIFIED: no-op
-        VOTE_OPTION_NO: no
-        VOTE_OPTION_YES: yes
-        VOTE_OPTION_ABSTAIN: abstain
-        VOTE_OPTION_NO_WITH_VETO: no-with-veto
+        unspecified: no-op
+        no: no
+        yes: yes
+        abstain: abstain
+        no_with_veto: no-with-veto
     metadata: metadata for the vote
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -508,7 +518,7 @@ Parameters:
 				return err
 			}
 
-			option, err := voteOptionFromString(args[2])
+			option, err := voteOptionFromString(normalizeVoteOption(args[2]))
 			if err != nil {
 				return err
 			}

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -93,23 +93,24 @@ func execFromString(execStr string) foundation.Exec {
 }
 
 func normalizeVoteOption(option string) string {
-	prefix := getEnumPrefix(foundation.VoteOption_name[0])
-	candidate := strings.ToUpper(prefix + option)
-	if _, ok := foundation.VoteOption_value[candidate]; ok {
-		return candidate
-	}
-
-	return option
+	normalizer := normalizer(foundation.VoteOption_name, foundation.VoteOption_value)
+	return normalizer(option)
 }
 
-func normalizeCensorshipAuthority(option string) string {
-	prefix := getEnumPrefix(foundation.CensorshipAuthority_name[0])
-	candidate := strings.ToUpper(prefix + option)
-	if _, ok := foundation.CensorshipAuthority_value[candidate]; ok {
-		return candidate
-	}
+func normalizeCensorshipAuthority(authority string) string {
+	normalizer := normalizer(foundation.CensorshipAuthority_name, foundation.CensorshipAuthority_value)
+	return normalizer(authority)
+}
 
-	return option
+func normalizer(mapToName map[int32]string, mapToValue map[string]int32) func(string) string {
+	return func(str string) string {
+		prefix := getEnumPrefix(mapToName[0])
+		candidate := strings.ToUpper(prefix + str)
+		if _, ok := mapToValue[candidate]; ok {
+			return candidate
+		}
+		return str
+	}
 }
 
 func getEnumPrefix(str string) string {

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -496,7 +496,6 @@ Parameters:
     proposal-id: unique ID of the proposal
     voter: voter account addresses.
     vote-option: choice of the voter(s)
-        unspecified: no-op
         no: no
         yes: yes
         abstain: abstain

--- a/x/foundation/client/testutil/suite.go
+++ b/x/foundation/client/testutil/suite.go
@@ -127,7 +127,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.createAccount("leavingmember", leavingMemberMnemonic)
 	s.createAccount("permanentmember", permanentMemberMnemonic)
 
-	s.proposalID = s.submitProposal(testdata.NewTestMsg(s.authority), false)
+	s.proposalID = s.submitProposal(testdata.NewTestMsg(s.authority))
 	s.vote(s.proposalID, []sdk.AccAddress{s.leavingMember, s.permanentMember})
 	s.Require().NoError(s.network.WaitForNextBlock())
 
@@ -142,7 +142,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 }
 
 // submit a proposal
-func (s *IntegrationTestSuite) submitProposal(msg sdk.Msg, try bool) uint64 {
+func (s *IntegrationTestSuite) submitProposal(msg sdk.Msg) uint64 {
 	val := s.network.Validators[0]
 
 	proposers := []string{s.permanentMember.String()}
@@ -154,9 +154,6 @@ func (s *IntegrationTestSuite) submitProposal(msg sdk.Msg, try bool) uint64 {
 		string(proposersBz),
 		s.msgToString(msg),
 	}, commonArgs...)
-	if try {
-		args = append(args, fmt.Sprintf("--%s=%s", cli.FlagExec, cli.ExecTry))
-	}
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, cli.NewTxCmdSubmitProposal(), args)
 	s.Require().NoError(err)
 

--- a/x/foundation/client/testutil/tx.go
+++ b/x/foundation/client/testutil/tx.go
@@ -335,7 +335,16 @@ func (s *IntegrationTestSuite) TestNewTxCmdVote() {
 			[]string{
 				fmt.Sprint(id),
 				s.permanentMember.String(),
-				"VOTE_OPTION_YES",
+				foundation.VOTE_OPTION_YES.String(),
+				"test vote",
+			},
+			true,
+		},
+		"valid abbreviation": {
+			[]string{
+				fmt.Sprint(id),
+				s.permanentMember.String(),
+				"yes",
 				"test vote",
 			},
 			true,
@@ -344,7 +353,7 @@ func (s *IntegrationTestSuite) TestNewTxCmdVote() {
 			[]string{
 				fmt.Sprint(id),
 				s.permanentMember.String(),
-				"VOTE_OPTION_YES",
+				foundation.VOTE_OPTION_YES.String(),
 				"test vote",
 				"extra",
 			},

--- a/x/foundation/client/testutil/tx.go
+++ b/x/foundation/client/testutil/tx.go
@@ -327,6 +327,7 @@ func (s *IntegrationTestSuite) TestNewTxCmdVote() {
 	}
 
 	id := s.submitProposal(testdata.NewTestMsg(s.authority), false)
+	id2 := s.submitProposal(testdata.NewTestMsg(s.authority), false)
 	testCases := map[string]struct {
 		args  []string
 		valid bool
@@ -342,7 +343,7 @@ func (s *IntegrationTestSuite) TestNewTxCmdVote() {
 		},
 		"valid abbreviation": {
 			[]string{
-				fmt.Sprint(id),
+				fmt.Sprint(id2),
 				s.permanentMember.String(),
 				"yes",
 				"test vote",

--- a/x/foundation/client/testutil/tx.go
+++ b/x/foundation/client/testutil/tx.go
@@ -276,7 +276,7 @@ func (s *IntegrationTestSuite) TestNewTxCmdWithdrawProposal() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10)))),
 	}
 
-	id := s.submitProposal(testdata.NewTestMsg(s.authority), false)
+	id := s.submitProposal(testdata.NewTestMsg(s.authority))
 	testCases := map[string]struct {
 		args  []string
 		valid bool
@@ -326,8 +326,8 @@ func (s *IntegrationTestSuite) TestNewTxCmdVote() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10)))),
 	}
 
-	id := s.submitProposal(testdata.NewTestMsg(s.authority), false)
-	id2 := s.submitProposal(testdata.NewTestMsg(s.authority), false)
+	id := s.submitProposal(testdata.NewTestMsg(s.authority))
+	id2 := s.submitProposal(testdata.NewTestMsg(s.authority))
 	testCases := map[string]struct {
 		args  []string
 		valid bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would allow users to use abbreviated vote option for the foundation vote cli.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
