### PR TITLE
fix: fix slice init length

### DIFF
--- a/x/auth/vesting/types/period.go
+++ b/x/auth/vesting/types/period.go
@@ -50,7 +50,7 @@ func (p Periods) TotalAmount() sdk.Coins {
 
 // String implements the fmt.Stringer interface
 func (p Periods) String() string {
-	periodsListString := make([]string, len(p))
+	periodsListString := make([]string, 0, len(p))
 	for _, period := range p {
 		periodsListString = append(periodsListString, period.String())
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


The intention here should be to initialize a slice with a capacity of   `len(p)`  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW



## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix slice init length

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
